### PR TITLE
Port forwarding: UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "eslint-plugin-nuxt": "^2.0.0",
         "eslint-plugin-vue": "^7.4.1",
         "follow-redirects": "^1.13.1",
+        "js-yaml-loader": "^1.2.2",
         "node-sass": "^5.0.0",
         "nuxt": "^2.14.12",
         "nuxtron": "^0.3.1",
@@ -1716,8 +1717,6 @@
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
         "fs-extra": "^8.1.0",
-        "global-agent": "^2.0.2",
-        "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
         "progress": "^2.0.3",
         "semver": "^6.2.0",
@@ -2641,7 +2640,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -2955,7 +2953,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -3298,7 +3295,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -3459,7 +3455,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -3652,7 +3647,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -3856,7 +3850,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -3938,7 +3931,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -5320,7 +5312,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -5723,7 +5714,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -7392,7 +7382,6 @@
         "thread-loader": "^2.1.3",
         "url-loader": "^2.2.0",
         "vue-loader": "^15.9.2",
-        "vue-loader-v16": "npm:vue-loader@^16.1.0",
         "vue-style-loader": "^4.1.2",
         "webpack": "^4.0.0",
         "webpack-bundle-analyzer": "^3.8.0",
@@ -7572,7 +7561,6 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.14",
         "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },
@@ -9176,7 +9164,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -10673,7 +10660,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -11171,7 +11157,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -13905,7 +13890,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -14395,7 +14379,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -14544,7 +14527,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -14848,8 +14830,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -20252,7 +20233,6 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -21037,6 +21017,17 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/js-yaml-loader": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml-loader/-/js-yaml-loader-1.2.2.tgz",
+      "integrity": "sha512-H+NeuNrG6uOs/WMjna2SjkaCw13rMWiT/D7l9+9x5n8aq88BDsh2sRmdfxckWPIHtViYHWRG6XiCKYvS1dfyLg==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "loader-utils": "^1.2.3",
+        "un-eval": "^1.2.0"
+      }
+    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -21213,9 +21204,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -23573,7 +23561,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -24564,7 +24551,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -27875,9 +27861,6 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
       "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
       "dev": true,
-      "dependencies": {
-        "clipboard": "^2.0.0"
-      },
       "optionalDependencies": {
         "clipboard": "^2.0.0"
       }
@@ -32738,6 +32721,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/un-eval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/un-eval/-/un-eval-1.2.0.tgz",
+      "integrity": "sha512-Wlj/pum6dQtGTPD/lclDtoVPkSfpjPfy1dwnnKw/sZP5DpBH9fLhBgQfsqNhe5/gS1D+vkZUuB771NRMUPA5CA==",
+      "dev": true
+    },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -34280,10 +34269,8 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -34367,7 +34354,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -34830,7 +34816,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -53060,6 +53045,17 @@
         "esprima": "^4.0.0"
       }
     },
+    "js-yaml-loader": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml-loader/-/js-yaml-loader-1.2.2.tgz",
+      "integrity": "sha512-H+NeuNrG6uOs/WMjna2SjkaCw13rMWiT/D7l9+9x5n8aq88BDsh2sRmdfxckWPIHtViYHWRG6XiCKYvS1dfyLg==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "loader-utils": "^1.2.3",
+        "un-eval": "^1.2.0"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -62552,6 +62548,12 @@
           "dev": true
         }
       }
+    },
+    "un-eval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/un-eval/-/un-eval-1.2.0.tgz",
+      "integrity": "sha512-Wlj/pum6dQtGTPD/lclDtoVPkSfpjPfy1dwnnKw/sZP5DpBH9fLhBgQfsqNhe5/gS1D+vkZUuB771NRMUPA5CA==",
+      "dev": true
     },
     "unbzip2-stream": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-nuxt": "^2.0.0",
     "eslint-plugin-vue": "^7.4.1",
     "follow-redirects": "^1.13.1",
+    "js-yaml-loader": "^1.2.2",
     "node-sass": "^5.0.0",
     "nuxt": "^2.14.12",
     "nuxtron": "^0.3.1",

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -54,7 +54,6 @@ export default {
 
 nav {
     background-color: var(--nav-bg);
-    height: 91vh;
     padding: 0;
     margin: 0;
     padding-top: 20px;

--- a/src/components/PortForwarding.vue
+++ b/src/components/PortForwarding.vue
@@ -1,0 +1,92 @@
+<!--
+  - This is the PortForwarding table in the K8s page.
+  -->
+<template>
+  <div>
+    <SortableTable
+      :headers="headers"
+      :rows="rows"
+      key-field="key"
+      default-sort-by="namespace"
+      :table-actions="false"
+      :paging="true"
+    >
+      <template #row-actions="{row}">
+        <button
+          v-if="row.listenPort"
+          class="btn btn-sm role-tertiary"
+          @click="update(false, row)"
+        >
+          Cancel
+        </button>
+        <button
+          v-else
+          class="btn btn-sm role-tertiary"
+          @click="update(true, row)"
+        >
+          Forward
+        </button>
+      </template>
+    </SortableTable>
+  </div>
+</template>
+
+<script>
+import SortableTable from '@/components/SortableTable';
+import { ipcRenderer } from 'electron';
+
+export default {
+  components: {
+    SortableTable,
+  },
+  props: {
+    services: {
+      type:     Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      headers: [
+        {
+          name:  'namespace',
+          label: 'Namespace',
+          sort:  ['namespace', 'name'],
+        },
+        {
+          name:  'name',
+          label: 'Name',
+          sort:  ['name', 'namespace'],
+        },
+        {
+          name:  'portName',
+          label: 'Port',
+          sort:  ['portName', 'namespace', 'name'],
+        },
+        {
+          name:  'listenPort',
+          label: 'Local Port',
+          sort:  ['listenPort', 'namespace', 'name'],
+        },
+      ],
+    };
+  },
+  computed: {
+    rows() {
+      return this.services.map(service => ({
+        namespace:  service.namespace,
+        name:       service.name,
+        portName:   service.portName || service.port,
+        port:       service.port,
+        listenPort: service.listenPort,
+        key:        `${service.namespace}/${service.name}:${service.portName}`,
+      }));
+    },
+  },
+  methods: {
+    update(state, service) {
+      ipcRenderer.invoke('service-forward', service, state);
+    },
+  },
+};
+</script>

--- a/src/components/PortForwarding.vue
+++ b/src/components/PortForwarding.vue
@@ -36,10 +36,8 @@ import SortableTable from '@/components/SortableTable';
 import { ipcRenderer } from 'electron';
 
 export default {
-  components: {
-    SortableTable,
-  },
-  props: {
+  components: { SortableTable },
+  props:      {
     services: {
       type:     Array,
       required: true,
@@ -79,7 +77,7 @@ export default {
         portName:   service.portName || service.port,
         port:       service.port,
         listenPort: service.listenPort,
-        key:        `${service.namespace}/${service.name}:${service.portName}`,
+        key:        `${ service.namespace }/${ service.name }:${ service.portName }`,
       }));
     },
   },

--- a/src/k8s-engine/client.js
+++ b/src/k8s-engine/client.js
@@ -303,6 +303,8 @@ class KubeClient extends events.EventEmitter {
       // The port forwarding has been cancelled, or we've set up a new one.
       server.close();
     }
+    // Trigger a UI refresh, because a new port forward was set up.
+    this.emit('service-changed', this.listServices());
   }
 
   /**
@@ -343,6 +345,7 @@ class KubeClient extends events.EventEmitter {
     this.#servers.delete(namespace, endpoint, port);
     if (server) {
       await new Promise(resolve => server.close(resolve));
+      this.emit('service-changed', this.listServices());
     }
   }
 

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -37,8 +37,10 @@ export default {
 
 .wrapper {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template: auto 1fr / repeat(4, 1fr);
   background-color: var(--body-bg);
+  width: 100vw;
+  height: 100vh;
 
   .header {
     grid-column: 1 / 5;
@@ -47,13 +49,14 @@ export default {
 
   .nav {
     grid-column: 1;
-    grid-row: 2 / 5;
+    grid-row: 2;
   }
 
   .body {
     grid-column: 2 / 5;
-    grid-row: 2 / 5;
+    grid-row: 2;
     padding: 20px 0 0 20px;
+    overflow: auto;
   }
 }
 

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -18,7 +18,7 @@ export default {
   },
 
   data() {
-    return { routes: ['/Welcome', '/K8s', '/Troubleshooting'] };
+    return { routes: ['/Welcome', '/K8s', '/PortForwarding', '/Troubleshooting'] };
   },
 
   head() {

--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -33,7 +33,8 @@ export default {
       // Add necessary loaders
       webpackConfig.module.rules.push({
         test:   /\.ya?ml(?:\?[a-z0-9=&.]+)?$/,
-        loader: 'file-loader',
+        loader: 'js-yaml-loader',
+        options: { name: '[path][name].[ext]' },
       });
     },
   },

--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -32,8 +32,8 @@ export default {
 
       // Add necessary loaders
       webpackConfig.module.rules.push({
-        test:   /\.ya?ml(?:\?[a-z0-9=&.]+)?$/,
-        loader: 'js-yaml-loader',
+        test:    /\.ya?ml(?:\?[a-z0-9=&.]+)?$/,
+        loader:  'js-yaml-loader',
         options: { name: '[path][name].[ext]' },
       });
     },

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -37,6 +37,9 @@
       </button>
       Resetting Kubernetes to default will delete all workloads and configuration
       <hr>
+      <h3>Services</h3>
+      <PortForwarding :services="services" />
+      <hr>
       <p>Supporting Utilities:</p>
       <Checkbox
         :label="'link to /usr/local/bin/kubectl'"
@@ -61,6 +64,7 @@
 
 <script>
 import Checkbox from '@/components/form/Checkbox.vue';
+import PortForwarding from '@/components/PortForwarding.vue';
 import RadioGroup from '@/components/form/RadioGroup.vue';
 import SystemPreferences from '@/components/SystemPreferences.vue';
 const os = require('os');
@@ -76,6 +80,7 @@ export default {
   title:      'Kubernetes Settings',
   components: {
     Checkbox,
+    PortForwarding,
     RadioGroup,
     SystemPreferences,
   },
@@ -85,6 +90,7 @@ export default {
       /** @type Settings */
       settings: ipcRenderer.sendSync('settings-read'),
       versions: require('../generated/versions.json'),
+      services: [],
       symlinks: {
         helm:    null,
         kubectl: null,
@@ -130,6 +136,11 @@ export default {
       console.log('settings have been updated');
       this.$data.settings = settings;
     });
+    ipcRenderer.on('service-changed', (event, services) => {
+      this.$data.services = services;
+    });
+    ipcRenderer.invoke('service-fetch')
+      .then(services => { this.$data.services = services; });
     ipcRenderer.on('install-state', (event, name, state) => {
       console.log(`install state changed for ${ name }: ${ state }`);
       this.$data.symlinks[name] = state;

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -37,9 +37,6 @@
       </button>
       Resetting Kubernetes to default will delete all workloads and configuration
       <hr>
-      <h3>Services</h3>
-      <PortForwarding :services="services" />
-      <hr>
       <p>Supporting Utilities:</p>
       <Checkbox
         :label="'link to /usr/local/bin/kubectl'"
@@ -64,7 +61,6 @@
 
 <script>
 import Checkbox from '@/components/form/Checkbox.vue';
-import PortForwarding from '@/components/PortForwarding.vue';
 import RadioGroup from '@/components/form/RadioGroup.vue';
 import SystemPreferences from '@/components/SystemPreferences.vue';
 const os = require('os');
@@ -80,7 +76,6 @@ export default {
   title:      'Kubernetes Settings',
   components: {
     Checkbox,
-    PortForwarding,
     RadioGroup,
     SystemPreferences,
   },
@@ -90,7 +85,6 @@ export default {
       /** @type Settings */
       settings: ipcRenderer.sendSync('settings-read'),
       versions: require('../generated/versions.json'),
-      services: [],
       symlinks: {
         helm:    null,
         kubectl: null,
@@ -136,11 +130,6 @@ export default {
       console.log('settings have been updated');
       this.$data.settings = settings;
     });
-    ipcRenderer.on('service-changed', (event, services) => {
-      this.$data.services = services;
-    });
-    ipcRenderer.invoke('service-fetch')
-      .then(services => { this.$data.services = services; });
     ipcRenderer.on('install-state', (event, name, state) => {
       console.log(`install state changed for ${ name }: ${ state }`);
       this.$data.symlinks[name] = state;

--- a/src/pages/PortForwarding.vue
+++ b/src/pages/PortForwarding.vue
@@ -2,7 +2,7 @@
   name: Port Forwarding
 </router>
 <template>
-  <PortForwarding :services="services" />
+  <PortForwarding class="content" :services="services" />
 </template>
 
 <script>
@@ -28,3 +28,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+  .content {
+    padding: 20px;
+  }
+</style>

--- a/src/pages/PortForwarding.vue
+++ b/src/pages/PortForwarding.vue
@@ -1,0 +1,30 @@
+<router lang="yaml">
+  name: Port Forwarding
+</router>
+<template>
+  <PortForwarding :services="services" />
+</template>
+
+<script>
+import PortForwarding from '@/components/PortForwarding.vue';
+import { ipcRenderer} from 'electron';
+
+export default {
+  components: {PortForwarding},
+  data() {
+    return {
+      services: [],
+    }
+  },
+
+  mounted() {
+    ipcRenderer.on('service-changed', (event, services) => {
+      this.$data.services = services;
+    });
+    ipcRenderer.invoke('service-fetch')
+      .then((services) => {
+        this.$data.services = services;
+      });
+  }
+}
+</script>

--- a/src/pages/PortForwarding.vue
+++ b/src/pages/PortForwarding.vue
@@ -7,14 +7,12 @@
 
 <script>
 import PortForwarding from '@/components/PortForwarding.vue';
-import { ipcRenderer} from 'electron';
+import { ipcRenderer } from 'electron';
 
 export default {
-  components: {PortForwarding},
+  components: { PortForwarding },
   data() {
-    return {
-      services: [],
-    }
+    return { services: [] };
   },
 
   mounted() {
@@ -26,7 +24,7 @@ export default {
         this.$data.services = services;
       });
   }
-}
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
This is the first go of the UI for managing port forwards, for #53.

This is based on #106 and should not be merged before that one.

Screenshot:
<img width="952" alt="image" src="https://user-images.githubusercontent.com/3977982/107586738-630d4a00-6bb5-11eb-843c-b6f3c73d6e16.png">

The port forwarding table might be too big to fit in the Kubernetes Settings screen; we might want to break it out into a separate one.  The vertical scrollbar, especially when there's non-table things on the same screen, looks kind of bad.

We may also want to attempt to prevent people from manually unhooking the port forwarding for the dashboard.