### PR TITLE
components/SystemPreferences: use a minimum of two cores

### DIFF
--- a/src/components/SystemPreferences.vue
+++ b/src/components/SystemPreferences.vue
@@ -35,7 +35,7 @@ export default {
     },
     minNumCPUs: {
       type:    Number,
-      default: 1,
+      default: 2,
     },
     reservedNumCPUs: {
       type:    Number,


### PR DESCRIPTION
Minikube will refuse to start if we provide less than two cores.  So limit the CPUs slider to at least two cores, as otherwise we will get an error on attempting to start the cluster (and result in a broken cluster).