### PR TITLE
K8s: show warning when cpu/memory is in reserved range

### DIFF
--- a/src/components/SystemPreferences.vue
+++ b/src/components/SystemPreferences.vue
@@ -98,14 +98,26 @@ export default {
         [
           percent(Math.max(0, this.availNumCPUs - this.reservedNumCPUs)),
           percent(this.availNumCPUs),
-          { backgroundColor: 'orange' },
+          {},
         ],
       ];
     },
     updatedMemory(value) {
+      let warningMessage = '';
+
+      if (value > this.availMemoryInGB - this.reservedMemoryInGB) {
+        warningMessage = `Allocating ${ value } GB to the virtual machine may cause your host machine to be sluggish.`;
+      }
+      this.$emit('warning', 'memory', warningMessage);
       this.$emit('updateMemory', value);
     },
     updatedCPU(value) {
+      let warningMessage = '';
+
+      if (value > this.availNumCPUs - this.reservedNumCPUs) {
+        warningMessage = `Allocating ${ value } CPUs to the virtual machine may cause your host machine to be sluggish.`;
+      }
+      this.$emit('warning', 'cpu', warningMessage);
       this.$emit('updateCPU', value);
     },
     makeMarks(min, max) {


### PR DESCRIPTION
This adds an error notification in the K8s page that will show a message if the CPU / memory settings are eating into the reserved range.

I did the wrong thing for #103 but this still seemed useful… going back to _actually_ work on #103 now :D