### PR TITLE
components/SystemPreferences: fix for dark mode

### DIFF
--- a/src/components/SystemPreferences.vue
+++ b/src/components/SystemPreferences.vue
@@ -193,8 +193,18 @@ div.slider-label {
   margin-top: 6px;
 }
 
+.vue-slider >>> .vue-slider-rail {
+  background-color: var(--muted);
+}
+.vue-slider >>> .vue-slider-mark {
+  background-color: var(--muted-banner-bg);
+}
+.vue-slider >>> .vue-slider-dot-handle {
+  background-color: var(--body-bg);
+  box-shadow: 0.5px 0.5px 2px 1px var(--darker);
+}
 .vue-slider >>> .vue-slider-process {
-  background-color: orange;
+  background-color: var(--error);
 }
 
 </style>


### PR DESCRIPTION
The sliders were not correctly styled under dark mode; this makes it better (mostly).

Light: 
![image](https://user-images.githubusercontent.com/3977982/108564488-09dd9e80-72b8-11eb-9c2f-1d4e6a903fa9.png)

Dark: 
![image](https://user-images.githubusercontent.com/3977982/108564512-14983380-72b8-11eb-946d-b4371093244c.png)

