### PR TITLE
k8s-engine: make a fast reset

### DIFF
--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -61,7 +61,7 @@ class Minikube extends EventEmitter {
 
   /**
    * #currentType is set if we're in the process of changing states.
-   * @type {string}
+   * @type { "start" | "stop" | "del" | "reset" }
    */
   #currentType
 
@@ -73,6 +73,47 @@ class Minikube extends EventEmitter {
 
   get state() {
     return this.#state;
+  }
+
+  /**
+   * Execute minikube with the given arguments.
+   * @param {...string} args Arguments to minikube
+   * @returns {Promise<{stdout: string, stderr: string}>}
+   */
+  async exec(...args) {
+    let opts = {
+      env: {
+        ...process.env,
+        MINIKUBE_HOME:    paths.data(),
+        MINIKUBE_PROFILE: 'rancher-desktop'
+      }
+    };
+
+    if (args.concat().pop() instanceof Object) {
+      opts = { ...opts, ...args.pop() };
+    }
+    const child = spawn(resources.executable('minikube'), args, opts);
+
+    this.#current = child;
+    const result = { stdout: '', stderr: '' };
+
+    return await new Promise((resolve, reject) => {
+      child.on('stdout', (data) => {
+        result.stdout += data;
+      });
+      child.on('stderr', (data) => {
+        result.stderr += data;
+      });
+      child.on('exit', (code, sig) => {
+        if (code === 0) {
+          resolve(result);
+        } else if (sig !== undefined) {
+          reject({ ...result, signal: sig });
+        } else {
+          reject(result);
+        }
+      });
+    });
   }
 
   /**
@@ -315,6 +356,38 @@ class Minikube extends EventEmitter {
         }
       });
     });
+  }
+
+  async reset(version) {
+    while (this.#currentType !== undefined) {
+      await sleep(500);
+    }
+    if (![K8s.State.STARTED, K8s.State.READY].includes(this.state)) {
+      return;
+    }
+    this.#currentType = 'reset';
+    try {
+      const sudo = ['ssh', '--', 'sudo'];
+
+      await this.exec(...sudo, 'systemctl', 'stop', 'kubelet.service', { stdio: 'inherit' });
+      await this.exec(...sudo, 'rm', '-rf', '/var/lib/k3s/server/db', { stdio: 'inherit' });
+      if (version) {
+        // change versions here
+      }
+      await this.exec(...sudo, 'systemctl', 'start', 'kubelet.service', { stdio: 'inherit' });
+      await this.exec(...sudo, 'systemctl', 'is-active', '--wait', 'kubelet.service', { stdio: 'inherit' });
+      this.#state = this.#state;
+    } catch (error) {
+      // The cluster is probably not running correctly anymore, oops.
+      this.#state = K8s.State.ERROR;
+      throw {
+        ...error,
+        context: 'resetting minikube',
+        message: error.stderr
+      };
+    } finally {
+      this.clear();
+    }
   }
 
   clear() {

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -142,7 +142,7 @@ export default {
     // Reset a Kubernetes cluster to default at the same version
     reset() {
       this.state = K8s.State.STOPPING;
-      ipcRenderer.send('k8s-reset', 'Reset Kubernetes to default');
+      ipcRenderer.send('k8s-reset', 'fast');
     },
     restart() {
       this.state = K8s.State.STOPPING;


### PR DESCRIPTION
The fast reset just deletes the data and restarts k8s; it does _not_ destroy the VM.  This makes things significantly faster, but doesn't do quite as complete a job.

This fixes #104 but the UX isn't quite ideal, I think.