### PR TITLE
nuxt.config: set <meta charset>

### DIFF
--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -48,6 +48,7 @@ export default {
     '@/assets/styles/app.scss',
   ],
   generate:         { devtools: isDevelopment },
+  head:             { meta: [{ charset: 'utf-8' }] },
   loading:          false,
   loadingIndicator: false,
   modules:          [


### PR DESCRIPTION
Babel was generating JavaScript that assumed UTF-8 charset; however, we were not specifying the charset, leading the browser to assume something else (probably latin1?).  This lead to script errors loading the initial page (due to some esprima regular expressions breaking) in packaged builds.

It appears that setting a `<meta charset="utf-8">` was enough to fix the issue; there does not appear to be a way to manually set `charset=` on the generated `<script>` tags.

This fixes #137.