### PR TITLE
K8s: fix changing versions

### DIFF
--- a/src/k8s-engine/homestead.js
+++ b/src/k8s-engine/homestead.js
@@ -163,6 +163,13 @@ async function ensure(state, client) {
   // times concurrently, we can stablize quickly.
   desiredState = state;
 
+  if (!client) {
+    if (desiredState !== State.NONE) {
+      console.log(`homestead.ensure: desiredState = ${ desiredState }: Can't do it as there's no current kubernetes client.`);
+    }
+    return;
+  }
+
   let ready = false;
 
   while (!ready) {

--- a/src/k8s-engine/homestead.js
+++ b/src/k8s-engine/homestead.js
@@ -167,6 +167,7 @@ async function ensure(state, client) {
     if (desiredState !== State.NONE) {
       console.log(`homestead.ensure: desiredState = ${ desiredState }: Can't do it as there's no current kubernetes client.`);
     }
+
     return;
   }
 

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -477,6 +477,7 @@ class Minikube extends EventEmitter {
   async #installRancher() {
     if (!this.#client) {
       console.log(`No kubernetes cluster to install homestead on`);
+
       return;
     }
     // Ensure homestead is running
@@ -485,7 +486,8 @@ class Minikube extends EventEmitter {
       this.#state = K8s.State.STARTED;
     }
     const mode = this.cfg?.rancherMode || 'HOMESTEAD';
-    console.log(`${ mode === Homestead.State.HOMESTEAD ? 'starting' : 'shutting down'} homestead`);
+
+    console.log(`${ mode === Homestead.State.HOMESTEAD ? 'starting' : 'shutting down' } homestead`);
 
     try {
       await Homestead.ensure(mode, this.#client);
@@ -508,6 +510,7 @@ class Minikube extends EventEmitter {
   #onSettingsChanged(settings) {
     // Don't bother updating the rancher install if the user has asked to change k8s versions
     const allowInstallRancher = (settings.kubernetes.version === this.cfg.version);
+
     this.cfg = settings.kubernetes;
     // Ensure that the Rancher UI is in the correct state
     if (allowInstallRancher && (this.#state === K8s.State.STARTED || this.#state === K8s.State.READY)) {

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -475,13 +475,17 @@ class Minikube extends EventEmitter {
    * Install Rancher / homestead.
    */
   async #installRancher() {
+    if (!this.#client) {
+      console.log(`No kubernetes cluster to install homestead on`);
+      return;
+    }
     // Ensure homestead is running
-    console.log('starting homestead');
     if (this.#state === K8s.State.READY) {
       // Mark this as not quite ready yet.
       this.#state = K8s.State.STARTED;
     }
     const mode = this.cfg?.rancherMode || 'HOMESTEAD';
+    console.log(`${ mode === Homestead.State.HOMESTEAD ? 'starting' : 'shutting down'} homestead`);
 
     try {
       await Homestead.ensure(mode, this.#client);
@@ -502,9 +506,11 @@ class Minikube extends EventEmitter {
    * @param {Settings} settings The new settings.
    */
   #onSettingsChanged(settings) {
+    // Don't bother updating the rancher install if the user has asked to change k8s versions
+    const allowInstallRancher = (settings.kubernetes.version === this.cfg.version);
     this.cfg = settings.kubernetes;
     // Ensure that the Rancher UI is in the correct state
-    if (this.#state === K8s.State.STARTED || this.#state === K8s.State.READY) {
+    if (allowInstallRancher && (this.#state === K8s.State.STARTED || this.#state === K8s.State.READY)) {
       this.#installRancher().catch((error) => {
         // TODO: handle this correctly
         console.error(error);

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -101,7 +101,7 @@ export default {
       return os.cpus().length;
     },
     cannotReset() {
-      return (this.state !== K8s.State.STARTED && this.state !== K8s.State.READY);
+      return ![K8s.State.STARTED, K8s.State.READY, K8s.State.ERROR].includes(this.state);
     },
     latestWarning() {
       return this.warnings[Object.keys(this.warnings).pop()] || '';
@@ -141,8 +141,14 @@ export default {
   methods: {
     // Reset a Kubernetes cluster to default at the same version
     reset() {
+      const oldState = this.state;
+
       this.state = K8s.State.STOPPING;
-      ipcRenderer.send('k8s-reset', 'fast');
+      if ([K8s.State.STARTED, K8s.State.READY].includes(oldState)) {
+        ipcRenderer.send('k8s-reset', 'fast');
+      } else {
+        ipcRenderer.send('k8s-reset', 'slow');
+      }
     },
     restart() {
       this.state = K8s.State.STOPPING;


### PR DESCRIPTION
Changing versions was broken, because we switch to doing fast resets, which means we never got far enough to supply a version string.  Change things so that:

- The k8s engine records the version we started with.
- If the version doesn't match, do a slow reset instead of a fast one.
- Allow resets from the error state, which is always slow.