### PR TITLE
Removing logs that are showing as error

### DIFF
--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -214,13 +214,7 @@ class Minikube extends EventEmitter {
           // Run the callback function.
           if (code === 0) {
             this.#state = K8s.State.STARTED;
-            if (errorMessage) {
-              reject({
-                context: 'starting minikube', errorCode: code, message: errorMessage
-              });
-            } else {
-              resolve();
-            }
+            resolve();
           } else if (sig === 'SIGINT') {
             // If the user manually stops before we finish, we get a SIGNINT.
             this.#state = K8s.State.STOPPED;


### PR DESCRIPTION
minikube is putting out debug/log info on stderr. This is a
common practice. Even when the exit code is 0 (as in everything
is fine) we had been rejecting if there was any data from stderr.
Logs were causing this. Removing the rejection if there is
data in stderr but it exited properly.