### PR TITLE
Make it possible to prepare development environment on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,63 @@ brew install pkg-config cairo pango libpng jpeg giflib librsvg
 sudo apt-get install -y libcairo2-dev libpango1.0-dev libpng-dev libjpeg-dev libgif-dev librsvg2-dev
 ```
 
+### Windows
+
+Experimental Windows support is in development.
+
+#### Quick Start
+
+1. Download a Microsoft Windows 10 [development virtual machine].
+2. Open a privileged PowerShell prompt (hit Windows Key + `X` and open
+   `Windows PowerShell (Admin)`).
+3. Run the [automated setup script]:
+   ```powershell
+   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+   iwr -useb 'https://github.com/rancher-sandbox/rd/raw/main/scripts/windows-setup.ps1' | iex
+   ```
+4. Close the privileged PowerShell prompt.
+
+You are now ready to clone the repository and run `npm install`.
+
+[development virtual machine]: https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/
+[automated setup script]: ./scripts/windows-setup.ps1
+
+#### Manual Development Environment Setup
+
+1. Download and install [Visual Studio], taking care to install:
+   - MSVC v141 - VS 2017 C++ x64/x86 build tools (v14.16)
+   - MSVC v142 - VS 2019 C++ x64/x86 build tools (Latest)
+2. Download the [GTK+ Win64 bundle]; it is recommended to install it in the
+   default location at `C:\GTK`.
+3. Download the [libjpeg-turbo development files]; it is recommended to install
+   it in the default location at `C:\libjpeg-turbo64`.
+4. Install git, Python 2.x, and NodeJS.
+   1. Install [Scoop] via `iwr -useb get.scoop.sh | iex`
+   2. Install git and nvm via `scoop install git nvm`
+   3. Add the old versions bucket via `scoop bucket add versions`
+   4. Install nvm and Python 2 via `scoop install python27`
+   5. Install NodeJS via `nvm install latest`
+      * Remember to use it by running `nvm use $(nvm list)`
+5. Configure NPM to use the version of MSBuild installed:
+   ```powershell
+   npm config set msbuild_path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
+   ```
+   Note that this is the default path; the path on your system may differ.
+
+If you have customized the GTK and libjpeg paths, you will need to run
+`npm install` with the `GYP_DEFINES` variable set to point to them.  In
+PowerShell, this would look something like:
+
+```powershell
+$Env:GYP_DEFINES = 'GTK_Root="C:/Path/To/GTK" jpeg_root="C:/Path/To/libjpeg"'
+```
+
+[Visual Studio]: https://visualstudio.microsoft.com/
+[GTK+ Win64 bundle]: https://download.gnome.org/binaries/win64/gtk+/2.22/
+[libjpeg-turbo development files]: https://sourceforge.net/projects/libjpeg-turbo/files/2.0.6/libjpeg-turbo-2.0.6-vc64.exe/download
+[Scoop]: https://scoop.sh/
+
 ## How To Run
 
 Use the following commands. The first two are needed the first time or after an
@@ -32,7 +89,7 @@ update is pulled from upstream. The 3rd command is needed for follow-up starts.
 npm install
 npm run-script setupmac
 npm run dev
-``` 
+```
 
 Note, `setupmac` is a script that pulls down outside resources for mac, puts them
 in the right place, and makes sure their permissions are set properly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "eslint-plugin-vue": "^7.4.1",
         "follow-redirects": "^1.13.1",
         "js-yaml-loader": "^1.2.2",
+        "nan": "2.14.0 <2.14.1",
         "node-sass": "^4.14.1",
         "nuxt": "^2.14.12",
         "sass-loader": "^10.1.1",
@@ -20995,9 +20996,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "node_modules/nanoid": {
       "version": "3.1.22",
@@ -49595,9 +49596,9 @@
       }
     },
     "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nanoid": {
       "version": "3.1.22",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-vue": "^7.4.1",
     "follow-redirects": "^1.13.1",
     "js-yaml-loader": "^1.2.2",
+    "nan": "2.14.0 <2.14.1",
     "node-sass": "^4.14.1",
     "nuxt": "^2.14.12",
     "sass-loader": "^10.1.1",

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -6,6 +6,7 @@ import childProcess from 'child_process';
 import { createRequire } from 'module';
 import path from 'path';
 import url from 'url';
+import util from 'util';
 import webpack from 'webpack';
 
 export default {
@@ -19,6 +20,8 @@ export default {
   get serial() {
     return process.argv.some(x => x === '--serial');
   },
+
+  sleep: util.promisify(setTimeout),
 
   /**
    * Get the root directory of the repository.

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -1,5 +1,8 @@
 
+$InformationPreference = 'Continue'
+
 ## Download GTK
+Write-Information 'Downloading GTK...'
 $GTKFile = "$ENV:TEMP\gtk.zip"
 
 try {
@@ -13,6 +16,7 @@ finally {
 }
 
 ## Download libjpeg-turbo
+Write-Information 'Downloading libjpeg-turbo...'
 $JPEGFile = "$ENV:TEMP\jpeg-turbo.exe"
 
 try {
@@ -29,16 +33,20 @@ try {
 }
 
 ## Install missing Visual Studio bits.
-& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' modify `
+Write-Information 'Installing missing Visual Studio components...'
+& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' update `
     --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community' `
     --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 `
-    --add Microsoft.VisualStudio.Component.Git `
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
     --passive
 
-## Install Scoop and from there, NVM + Python 2
+## Install Scoop and from there, Git + NVM + Python 2
+Write-Information 'Installing Git, NodeJS & Python 2...'
 
 Invoke-WebRequest -UseBasicParsing -Uri get.scoop.sh | Invoke-Expression
+scoop install git
 scoop bucket add versions
 scoop install nvm python27
 nvm install latest
 nvm use $(nvm list)
+npm config set msbuild_path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -1,0 +1,50 @@
+
+## Download GTK
+$GTKFile = "$ENV:TEMP\gtk.zip"
+
+try {
+    Invoke-WebRequest -Uri 'https://download.gnome.org/binaries/win64/gtk+/2.22/gtk%2B-bundle_2.22.1-20101229_win64.zip' `
+        -UseBasicParsing -OutFile $GTKFile
+
+    Microsoft.PowerShell.Archive\Expand-Archive -Path $GTKFile -DestinationPath C:\GTK
+}
+finally {
+    Remove-Item $GTKFile
+}
+
+## Download libjpeg-turbo
+$JPEGFile = "$ENV:TEMP\jpeg-turbo.exe"
+
+try {
+    # SourceForge likes to do the redirect thing, so we need to ask it for the URL
+    Invoke-WebRequest -Uri 'https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.6/libjpeg-turbo-2.0.6-vc64.exe' `
+        -UseBasicParsing -OutFile $JPEGFile
+    $url = (Invoke-WebRequest -UseBasicParsing `
+        -Uri 'https://sourceforge.net/settings/mirror_choices?projectname=libjpeg-turbo&filename=2.0.6/libjpeg-turbo-2.0.6-vc64.exe' `
+    | Select-Object -ExpandProperty Links | Where-Object { $_.outerHTML -like '*direct link*' } | Select-Object -ExpandProperty href)
+    Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $JPEGFile
+    & $JPEGFile /D 'C:\libjpeg-turbo64' /S
+} finally {
+    Remove-Item $JPEGFile
+}
+
+## Install missing Visual Studio bits.
+& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' modify `
+    --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community' `
+    --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 `
+    --add Microsoft.VisualStudio.Component.Git `
+    --add Component.CPython2.x64 `
+    --passive
+# Not sure why Python wasn't added to the $PATH
+$path = [System.Environment]::GetEnvironmentVariable('PATH', [System.EnvironmentVariableTarget]::User).Split(';')
+if (-not $path -contains "C:\Python27amd64") {
+    $path += "C:\Python27amd64"
+    [System.Environment]::SetEnvironmentVariable('PATH', [String]::Join(';', $path), [System.EnvironmentVariableTarget]::User)
+}
+
+## Install Scoop and from there, NVM
+
+Invoke-WebRequest -UseBasicParsing -Uri get.scoop.sh | Invoke-Expression
+scoop install nvm
+nvm install latest
+nvm use $(nvm list)

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -33,18 +33,12 @@ try {
     --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community' `
     --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 `
     --add Microsoft.VisualStudio.Component.Git `
-    --add Component.CPython2.x64 `
     --passive
-# Not sure why Python wasn't added to the $PATH
-$path = [System.Environment]::GetEnvironmentVariable('PATH', [System.EnvironmentVariableTarget]::User).Split(';')
-if (-not $path -contains "C:\Python27amd64") {
-    $path += "C:\Python27amd64"
-    [System.Environment]::SetEnvironmentVariable('PATH', [String]::Join(';', $path), [System.EnvironmentVariableTarget]::User)
-}
 
-## Install Scoop and from there, NVM
+## Install Scoop and from there, NVM + Python 2
 
 Invoke-WebRequest -UseBasicParsing -Uri get.scoop.sh | Invoke-Expression
-scoop install nvm
+scoop bucket add versions
+scoop install nvm python27
 nvm install latest
 nvm use $(nvm list)

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -1,6 +1,12 @@
 
 $InformationPreference = 'Continue'
 
+## Update the Visual Studio Installer.  This can take a long time, so start this
+# first before doing anything else.
+Write-Information 'Updating Visual Studio components...'
+& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' update `
+    --passive
+
 ## Download GTK
 Write-Information 'Downloading GTK...'
 $GTKFile = "$ENV:TEMP\gtk.zip"
@@ -32,9 +38,11 @@ try {
     Remove-Item $JPEGFile
 }
 
-## Install missing Visual Studio bits.
-Write-Information 'Installing missing Visual Studio components...'
-& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' update `
+## Install additional Visual Studio components.  This depends on it already
+# having been updated.
+Write-Information 'Installing additional Visual Studio components...'
+Wait-Process -Name setup
+& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' modify `
     --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community' `
     --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
@@ -49,4 +57,8 @@ scoop bucket add versions
 scoop install nvm python27
 nvm install latest
 nvm use $(nvm list)
-npm config set msbuild_path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
+Write-Output 'msbuild_path=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe' > ~/.npmrc
+
+
+# Wait for Visual Studio Setup to finish
+Wait-Process -Name setup

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -42,6 +42,7 @@ try {
 ## Install additional Visual Studio components.  This depends on it already
 # having been updated.
 Write-Information 'Installing additional Visual Studio components...'
+Get-Process | Where-Object { $_.Name -eq 'setup' } | Wait-Process
 Wait-Process -Name setup
 & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' modify `
     --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community' `
@@ -63,4 +64,4 @@ Write-Output 'msbuild_path=C:\Program Files (x86)\Microsoft Visual Studio\2019\C
 
 
 # Wait for Visual Studio Setup to finish
-Wait-Process -Name setup
+Get-Process | Where-Object { $_.Name -eq 'setup' } | Wait-Process

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -5,6 +5,7 @@ $InformationPreference = 'Continue'
 # first before doing anything else.
 Write-Information 'Updating Visual Studio components...'
 & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' update `
+    --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community' `
     --passive
 
 ## Download GTK

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -57,7 +57,8 @@ scoop bucket add versions
 scoop install nvm python27
 nvm install latest
 nvm use $(nvm list)
-Write-Output 'msbuild_path=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe' > ~/.npmrc
+Write-Output 'msbuild_path=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe' `
+  | Out-File -Encoding UTF8 -FilePath ~/.npmrc
 
 
 # Wait for Visual Studio Setup to finish


### PR DESCRIPTION
This fixes things so that `npm install` works, and `npm run build` / `npm run dev` does _something_.  None of the Windows backend exists, and we'll still require a replacement for `npm run setupmac`.