### PR TITLE
Update minikube to support rancher/kim

### DIFF
--- a/scripts/setupmac.js
+++ b/scripts/setupmac.js
@@ -6,7 +6,7 @@ fs.mkdirSync('./resources/darwin/bin', { recursive: true });
 
 const file = fs.createWriteStream('./resources/darwin/minikube');
 
-https.get('https://github.com/jandubois/minikube/releases/download/k3s0/minikube-darwin-amd64', (response) => {
+https.get('https://github.com/jandubois/minikube/releases/download/k3s1/minikube-darwin-amd64', (response) => {
   response.on('data', (data) => {
     file.write(data);
   });


### PR DESCRIPTION
The new minikube installs k3s into the default location at `/var/lib/rancher/k3s` and also uses the bundled containerd.

minikube will still install/run it's own containerd, but it will not be used for anything; just sitting idle.

This should enable work on #155 on macOS.

```
$ ./kim images
WARN[0000] Cannot find available builder daemon, attempting automatic installation...
INFO[0000] Applying node-role `builder` to `rancher-desktop`
INFO[0000] Asserting namespace `kube-image`
INFO[0000] Asserting TLS secrets
INFO[0000] Asserting service/endpoints
INFO[0000] Installing builder daemon
INFO[0000] Waiting on builder daemon availability...
INFO[0006] Waiting on builder daemon availability...
INFO[0013] Waiting on builder daemon availability...
IMAGE               TAG                 IMAGE ID            SIZE
moby/buildkit       v0.8.1              d877bfa959899       55.2MB
rancher/kim         v0.1.0-alpha.9      4a2d13f1add5c       12.6MB
```

I've tested that building images works as well.