### PR TITLE
Add a checkbox to control filtering out of system services.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
       "^.+\\.js$": "babel-jest",
       "^.+\\.vue$": "vue-jest"
     },
+    "moduleFileExtensions": [
+       "js", "json", "ts", "vue"
+    ],
     "modulePathIgnorePatterns": [
       "<rootDir>/dist"
     ],

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -22,6 +22,7 @@ const defaultSettings = {
     memoryInGB:  2,
     numberCPUs:  2,
   },
+  portForwarding: { includeKubernetesServices: false },
 };
 
 export type Settings = typeof defaultSettings;

--- a/src/pages/PortForwarding.vue
+++ b/src/pages/PortForwarding.vue
@@ -7,7 +7,7 @@
     :services="services"
     :include-kubernetes-services="settings.portForwarding.includeKubernetesServices"
     :k8s-state="state"
-    @change="onIncludeK8sServicesChanged"
+    @toggledServiceFilter="onIncludeK8sServicesChanged"
   />
 </template>
 
@@ -29,8 +29,8 @@ export default {
   },
 
   mounted() {
-    ipcRenderer.on('k8s-check-state', (event, stt) => {
-      this.$data.state = stt;
+    ipcRenderer.on('k8s-check-state', (event, state) => {
+      this.$data.state = state;
     });
     ipcRenderer.on('service-changed', (event, services) => {
       this.$data.services = services;

--- a/src/pages/PortForwarding.vue
+++ b/src/pages/PortForwarding.vue
@@ -6,6 +6,7 @@
     class="content"
     :services="services"
     :include-kubernetes-services="settings.portForwarding.includeKubernetesServices"
+    :k8s-state="state"
     @change="onIncludeK8sServicesChanged"
   />
 </template>
@@ -20,6 +21,7 @@ export default {
   components: { PortForwarding },
   data() {
     return {
+      state:         ipcRenderer.sendSync('k8s-state'),
       /** @type Settings */
       settings:      ipcRenderer.sendSync('settings-read'),
       services: []
@@ -27,6 +29,9 @@ export default {
   },
 
   mounted() {
+    ipcRenderer.on('k8s-check-state', (event, stt) => {
+      this.$data.state = stt;
+    });
     ipcRenderer.on('service-changed', (event, services) => {
       this.$data.services = services;
     });

--- a/src/pages/PortForwarding.vue
+++ b/src/pages/PortForwarding.vue
@@ -2,17 +2,28 @@
   name: Port Forwarding
 </router>
 <template>
-  <PortForwarding class="content" :services="services" />
+  <PortForwarding
+    class="content"
+    :services="services"
+    :include-kubernetes-services="settings.portForwarding.includeKubernetesServices"
+    @change="onIncludeK8sServicesChanged"
+  />
 </template>
 
 <script>
 import PortForwarding from '@/components/PortForwarding.vue';
 import { ipcRenderer } from 'electron';
 
+/** @typedef { import("../config/settings").Settings } Settings */
+
 export default {
   components: { PortForwarding },
   data() {
-    return { services: [] };
+    return {
+      /** @type Settings */
+      settings:      ipcRenderer.sendSync('settings-read'),
+      services: []
+    };
   },
 
   mounted() {
@@ -23,7 +34,20 @@ export default {
       .then((services) => {
         this.$data.services = services;
       });
-  }
+    ipcRenderer.on('settings-update', (event, settings) => {
+      // TODO: put in a status bar
+      this.$data.settings = settings;
+    });
+  },
+
+  methods: {
+    onIncludeK8sServicesChanged(value) {
+      if (value !== this.settings.portForwarding.includeKubernetesServices) {
+        ipcRenderer.invoke('settings-write',
+          { portForwarding: { includeKubernetesServices: value } } );
+      }
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
I tried writing a few unit tests on this, but ran into a blocker caused by `components/SortableTable` referencing `this.$router` and `this.$routes` and not finding a way to mock them (there's a really good one-year-old unanswered question on S/O that covers the same issue. Will revisit it if I get some traction there.

2nd commit: the checkbox is disabled unless K8s is running. 

Signed-off-by: Eric Promislow <epromislow@suse.com>