### PR TITLE
Jest: Ignore build & git directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
       "vue"
     ],
     "modulePathIgnorePatterns": [
-      "<rootDir>/dist"
+      "<rootDir>/dist",
+      "<rootDir>/src/dist",
+      "<rootDir>/.git"
     ],
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/src/config/emptyStubForJSLinter.js"


### PR DESCRIPTION
These directories can never contain node modules we care about for tests. Jest was keeping a watch on each directory, which causes issues on Windows as opened directories cannot be moved (which breaks the build process if there is a background jest process running).  The git directory part is purely optimization.