### PR TITLE
Electron-builder: set appId

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 productName: Rancher Desktop
 icon: ./resources/icons/logo-square-512.png
-appId: io.rancher.rd
+appId: io.rancher.rancher-desktop
 asar: true
 extraResources:
 - resources/

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,6 @@
 productName: Rancher Desktop
 icon: ./resources/icons/logo-square-512.png
+appId: io.rancher.rd
 asar: true
 extraResources:
 - resources/


### PR DESCRIPTION
We should set the appId so that upgrades of the installer package in the future will work correctly.