### PR TITLE
K8s: don't show tools symlinking on Windows

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 import { URL } from 'url';
 import Electron from 'electron';
 import _ from 'lodash';
@@ -49,11 +50,13 @@ Electron.app.whenReady().then(async() => {
     installExtension(VUEJS_DEVTOOLS);
   }
   if (await settings.isFirstRun()) {
-    await Promise.all([
-      linkResource('helm', true),
-      linkResource('kim', true),
-      linkResource('kubectl', true),
-    ]);
+    if (os.platform() === 'darwin') {
+      await Promise.all([
+        linkResource('helm', true),
+        linkResource('kim', true),
+        linkResource('kubectl', true),
+      ]);
+    }
   }
   try {
     cfg = settings.init(await K8s.availableVersions());
@@ -398,9 +401,11 @@ Electron.ipcMain.on('install-set', async(event, name, newState) => {
 Electron.ipcMain.on('factory-reset', async() => {
   // Clean up the Kubernetes cluster
   await k8smanager.factoryReset();
-  // Unlink binaries
-  for (const name of ['helm', 'kim', 'kubectl']) {
-    Electron.ipcMain.emit('install-set', { reply: () => { } }, name, false);
+  if (os.platform() === 'darwin') {
+    // Unlink binaries
+    for (const name of ['helm', 'kim', 'kubectl']) {
+      Electron.ipcMain.emit('install-set', { reply: () => { } }, name, false);
+    }
   }
   // Remove app settings
   await settings.clear();

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -35,28 +35,30 @@
     </button>
     Resetting Kubernetes to default will delete all workloads and configuration
     <hr>
-    <p>Supporting Utilities:</p>
-    <Checkbox
-      :label="'link to /usr/local/bin/kubectl'"
-      :disabled="symlinks.kubectl === null"
-      :value="symlinks.kubectl"
-      @input="value => handleCheckbox(value, 'kubectl')"
-    />
-    <hr>
-    <Checkbox
-      :label="'link to /usr/local/bin/helm'"
-      :disabled="symlinks.helm === null"
-      :value="symlinks.helm"
-      @input="value => handleCheckbox(value, 'helm')"
-    />
-    <hr>
-    <Checkbox
-      :label="'link to /usr/local/bin/kim'"
-      :disabled="symlinks.kim === null"
-      :value="symlinks.kim"
-      @input="value => handleCheckbox(value, 'kim')"
-    />
-    <hr>
+    <div v-if="hasToolsSymlinks">
+      <h2>Supporting Utilities:</h2>
+      <Checkbox
+        :label="'link to /usr/local/bin/kubectl'"
+        :disabled="symlinks.kubectl === null"
+        :value="symlinks.kubectl"
+        @input="value => handleCheckbox(value, 'kubectl')"
+      />
+      <hr>
+      <Checkbox
+        :label="'link to /usr/local/bin/helm'"
+        :disabled="symlinks.helm === null"
+        :value="symlinks.helm"
+        @input="value => handleCheckbox(value, 'helm')"
+      />
+      <hr>
+      <Checkbox
+        :label="'link to /usr/local/bin/kim'"
+        :disabled="symlinks.kim === null"
+        :value="symlinks.kim"
+        @input="value => handleCheckbox(value, 'kim')"
+      />
+      <hr>
+    </div>
   </Notifications>
 </template>
 
@@ -111,6 +113,9 @@ export default {
     },
     hasProgress() {
       return /^(?:win|darwin)/.test(os.platform());
+    },
+    hasToolsSymlinks() {
+      return os.platform() === 'darwin';
     },
     progressComputed() {
       return this.state === K8s.State.STARTING ? this.progress.current : this.progressMax;


### PR DESCRIPTION
It makes no sense to try to do symlinks to `/usr/local/bin` on Windows. Hide it there, and don't do the automatic linking on first run.
