### PR TITLE
Incrementing internal version to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rancher-desktop",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rancher-desktop",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@kubernetes/client-node": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rancher-desktop",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "scripts": {
     "dev": "node ./scripts/dev.mjs",
     "lint": "eslint --ignore-path=.gitignore --ext mjs,js,ts,vue --fix .",

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -19,7 +19,7 @@ const CURRENT_SETTINGS_VERSION = 2;
 const defaultSettings = {
   version:    CURRENT_SETTINGS_VERSION,
   kubernetes: {
-    version:     'v1.19.2',
+    version:     'v1.19.10',
     memoryInGB:  2,
     numberCPUs:  2,
   },

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -67,7 +67,7 @@ describe(K3sHelper, () => {
       expect(await subject.availableVersions).toHaveLength(0);
     });
     it('should ignore old versions', async() => {
-      expect(process('0.0.1')).toEqual(true);
+      expect(process('0.1.0')).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(0);
     });
     it('should ignore obsolete builds', async() => {


### PR DESCRIPTION
Also set a newer version of Kubernetes. The latest 1.19.

Note, many public clouds do not support 1.20 yet. This is why
1.19 was chosen as the default. We can update this in a future
release