### PR TITLE
Windows installer: add bin to PATH

### DIFF
--- a/build/add-to-path.ps1
+++ b/build/add-to-path.ps1
@@ -1,0 +1,11 @@
+# PowerShell script to add resources\win32\bin to the path
+
+param($InstallDir)
+
+$TargetUser = [System.EnvironmentVariableTarget]::User
+$path = [System.Environment]::GetEnvironmentVariable('PATH', $TargetUser) -split ';'
+$desiredPath = Join-Path $InstallDir 'resources\win32\bin'
+if ($path -notcontains $desiredPath) {
+  $path += $desiredPath
+  [System.Environment]::SetEnvironmentVariable('PATH', ($path -join ';'), $TargetUser)
+}

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,15 @@
+!macro customInstall
+  # Add the bin directory to the PATH
+  File "/oname=$PLUGINSDIR\add-to-path.ps1" "${BUILD_RESOURCES_DIR}\add-to-path.ps1"
+  ExecShellWait '' 'powershell.exe' \
+    '-NoProfile -NonInteractive -ExecutionPolicy RemoteSigned "$PLUGINSDIR\add-to-path.ps1" "$INSTDIR"' \
+    SW_HIDE
+!macroend
+
+!macro customUnInstall
+  # Remove the bin directory from the PATH
+  File "/oname=$PLUGINSDIR\remove-from-path.ps1" "${BUILD_RESOURCES_DIR}\remove-from-path.ps1"
+  ExecShellWait '' 'powershell.exe' \
+    '-NoProfile -NonInteractive -ExecutionPolicy RemoteSigned "$PLUGINSDIR\remove-from-path.ps1" "$INSTDIR"' \
+    SW_HIDE
+!macroend

--- a/build/remove-from-path.ps1
+++ b/build/remove-from-path.ps1
@@ -1,0 +1,12 @@
+# PowerShell script to remove resources\win32\bin from the path
+
+param($InstallDir)
+
+$TargetUser = [System.EnvironmentVariableTarget]::User
+[System.Collections.ArrayList]$path = [System.Environment]::GetEnvironmentVariable('PATH', $TargetUser) -split ';'
+$desiredPath = Join-Path $InstallDir 'resources\win32\bin'
+if ($path -contains $desiredPath) {
+  $path.Remove($desiredPath)
+  [System.Environment]::SetEnvironmentVariable('PATH', ($path -join ';'), $TargetUser)
+}
+$path = [System.Environment]::GetEnvironmentVariable('PATH', $TargetUser) -split ';'

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,3 +13,9 @@ mac:
   hardenedRuntime: true
   gatekeeperAssess: false
 afterSign: "scripts/notarize.js"
+win:
+  target: nsis
+  signingHashAlgorithms: [ sha256 ] # We only support Windows 10 + WSL2
+  requestedExecutionLevel: asInvoker # The _app_ doesn't need privileges
+nsis:
+  include: build/installer.nsh


### PR DESCRIPTION
This customizes the Windows installer to add the `resources\win32\bin` directory to the user's path (at the end, since we _always_ do it).

Fixes #174 (it's basically a warm-up for #185).

Note that I'm using an external PowerShell script because NSIS string manipulation has size limits that some users might hit.