### PR TITLE
Improve robustness

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -166,7 +166,7 @@ function refreshImageList() {
   imageManager.start();
 }
 
-Electron.ipcMain.on('confirm-do-image-deletion', (event, imageName, imageID) => {
+Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID) => {
   const choice = Electron.dialog.showMessageBoxSync( {
     message:   `Delete image ${ imageName }?`,
     type:      'warning',
@@ -177,7 +177,7 @@ Electron.ipcMain.on('confirm-do-image-deletion', (event, imageName, imageID) => 
   });
 
   if (choice === 0) {
-    imageManager.deleteImage(imageID);
+    await imageManager.deleteImage(imageID);
     refreshImageList();
   }
   event.reply('kim-process-ended', 0);

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -258,7 +258,10 @@ export default {
       if (this.fieldToClear) {
         this.fieldToClear = '';
       }
-      this.imageManagerOutput = this.imageOutputCuller.getProcessedData();
+      if (this.imageOutputCuller) {
+        // Don't know what would make this null, but it happens on windows sometimes
+        this.imageManagerOutput = this.imageOutputCuller.getProcessedData();
+      }
       if (this.kimRunningCommand?.startsWith('delete') && this.imageManagerOutput === '') {
         this.closeOutputWindow(null);
       }


### PR DESCRIPTION
Sometimes, on windows VMs, `[component/Images].imageOutputCuller`
becomes null unexpectedly. Allow for this so the `close output text'
button appears, and other UX happens smoothly.

No idea why this happens. I added `console.log` statements to track
when this field was assigned and didn't see an assigment from non-null
to null, but on event-end it was `null`.

Signed-off-by: Eric Promislow <epromislow@suse.com>