### PR TITLE
Ignore CRs in input files

### DIFF
--- a/src/utils/processOutputInterpreters/__tests__/kim-build-output.spec.js
+++ b/src/utils/processOutputInterpreters/__tests__/kim-build-output.spec.js
@@ -10,6 +10,6 @@ describe('kim build output', () => {
     const culler = new KimBuildOutputCuller();
 
     culler.addData(data);
-    expect(culler.getProcessedData()).toBe(data);
+    expect(culler.getProcessedData()).toBe(data.replace(/\r/g, ''));
   });
 });


### PR DESCRIPTION
On Windows the input files have CRs because they're managed by git.
They never end up in the internally generated text.

Signed-off-by: Eric Promislow <epromislow@suse.com>