### PR TITLE
Automatically install WSL in the Windows Installer

### DIFF
--- a/build/add-to-path.ps1
+++ b/build/add-to-path.ps1
@@ -8,4 +8,5 @@ $desiredPath = Join-Path $InstallDir 'resources\win32\bin'
 if ($path -notcontains $desiredPath) {
   $path += $desiredPath
   [System.Environment]::SetEnvironmentVariable('PATH', ($path -join ';'), $TargetUser)
+  Write-Output "Adding Kubernetes tools to PATH."
 }

--- a/build/install-wsl.ps1
+++ b/build/install-wsl.ps1
@@ -1,0 +1,83 @@
+# PowerShell script to ensure that WSL2 is installed on the machine.
+# This script returns 0 if it did nothing, or 100 if a restart is needed.
+
+# Magic PowerShell comment to require admin; see
+# https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-5.1#-runasadministrator
+#Requires -RunAsAdministrator
+
+param([ValidateSet("Initial", "Kernel")] $Stage = "Initial")
+
+$Global:NeedsRestart = $false
+
+function Install-Features {
+  # Install Windows features as needed.
+  $features = @('Microsoft-Windows-Subsystem-Linux', 'VirtualMachinePlatform')
+  foreach ($feature in $features) {
+    if (Get-WindowsOptionalFeature -Online -FeatureName:$feature | Where-Object State -ne Enabled) {
+      Write-Output "Installing Windows feature $feature"
+      Enable-WindowsOptionalFeature -FeatureName:$feature -Online -NoRestart
+      $Global:NeedsRestart = $true
+    }
+  }
+}
+
+function Set-RunPowerShellOnce {
+  Param([String] $Command)
+
+  Write-Verbose "Setting RunOnce to run PowerShell with ${Command}"
+  Set-ItemProperty `
+    -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce' `
+    -Name 'Rancher Desktop Install' `
+    -Value "`"$PSHOME\powershell.exe`" -NoProfile -ExecutionPolicy RemoteSigned -WindowStyle Hidden $Command"
+}
+
+function Install-Kernel {
+  # Install the updated WSL kernel, if not already installed.
+  $installed = Get-WmiObject Win32_Product -Filter 'IdentifyingNumber = "{8D646799-DB00-4000-AE7A-756A05A4F1D8}"'
+  if ($installed) {
+    $oldVersion = [System.Version]::Parse($installed.Version)
+    # The .net version comparator only does major/minor
+    Write-Output "Found existing WSL kernel $oldVersion"
+    if ($oldVersion -ge '5.4') {
+      # The old kernel is new enough, we don't need to do anything
+      return
+    }
+  }
+
+  if ($Global:NeedsRestart) {
+    # A restart is already scheduled (i.e. we need to install the Windows features); re-run the script on restart.
+    Write-Output "Will install Linux kernel after reboot."
+    $script = Join-Path ([System.IO.Path]::GetTempPath()) 'rancher-desktop-install.ps1'
+    Copy-Item $PSCommandPath $script
+    Set-RunPowerShellOnce "-File `"$script`" -Stage:Kernel"
+    return
+  }
+
+  $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) 'wsl-update.msi'
+  try {
+    $url = 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi'
+    Write-Output "Downloading Linux Kernel"
+    Invoke-WebRequest -UseBasicParsing $url -OutFile $tempFile
+    Write-Output "Installing new WSL kernel"
+    Start-Process -Wait 'msiexec.exe' -ArgumentList @('/forcerestart', '/passive', '/package', $tempFile, '/lv*', 'C:\rancher-desktop-install.log')
+  }
+  finally {
+    Remove-Item $tempFile
+  }
+}
+
+switch ($Stage) {
+  "Initial" {
+    Install-Features
+    Install-Kernel
+    if ($Global:NeedsRestart) {
+      Write-Output "A Windows restart is required."
+      exit 101
+    }
+  }
+  "Kernel" {
+    # Because we're doing this on restart, we need to clean up the script
+    Set-RunPowerShellOnce "-Command `"& { Remove-Item -LiteralPath '$PSCommandPath' }`""
+    Install-Kernel
+  }
+}

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -48,6 +48,11 @@
   Pop $R0
 !macroend
 
+# Bypass the install mode prompt, always install per-user.
+!macro customInstallMode
+  StrCpy $isForceCurrentInstall "1"
+!macroend
+
 !macro customUnInstall
   # Remove the bin directory from the PATH
   File "/oname=$PLUGINSDIR\remove-from-path.ps1" "${BUILD_RESOURCES_DIR}\remove-from-path.ps1"

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,3 +1,5 @@
+!include "x64.nsh"
+
 !macro customHeader
   # We always want to be admin, so that we can install Windows features.
   ManifestSupportedOS Win10
@@ -7,6 +9,12 @@
 !macroend
 
 !macro customInstall
+  Push $R0
+
+  ${If} ${IsWow64}
+    ${DisableX64FSRedirection}
+  ${EndIf}
+
   # Add the bin directory to the PATH
   File "/oname=$PLUGINSDIR\add-to-path.ps1" "${BUILD_RESOURCES_DIR}\add-to-path.ps1"
   nsExec::ExecToLog 'powershell.exe \
@@ -32,6 +40,12 @@
     # Unexpected exit code
     Abort "Unexpected error installing Windows subsystem for Linux: $R0"
   ${EndIf}
+
+  ${If} ${IsWow64}
+    ${EnableX64FSRedirection}
+  ${EndIf}
+
+  Pop $R0
 !macroend
 
 !macro customUnInstall

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,3 +1,9 @@
+!macro customHeader
+  # We always want to be admin, so that we can install Windows features.
+  ManifestSupportedOS Win10
+  RequestExecutionLevel admin
+!macroend
+
 !macro customInstall
   # Add the bin directory to the PATH
   File "/oname=$PLUGINSDIR\add-to-path.ps1" "${BUILD_RESOURCES_DIR}\add-to-path.ps1"

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -2,14 +2,36 @@
   # We always want to be admin, so that we can install Windows features.
   ManifestSupportedOS Win10
   RequestExecutionLevel admin
+  # Enable ShowInstDetails to get logs from scripts.
+  #ShowInstDetails show
 !macroend
 
 !macro customInstall
   # Add the bin directory to the PATH
   File "/oname=$PLUGINSDIR\add-to-path.ps1" "${BUILD_RESOURCES_DIR}\add-to-path.ps1"
-  ExecShellWait '' 'powershell.exe' \
-    '-NoProfile -NonInteractive -ExecutionPolicy RemoteSigned "$PLUGINSDIR\add-to-path.ps1" "$INSTDIR"' \
-    SW_HIDE
+  nsExec::ExecToLog 'powershell.exe \
+    -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned \
+    -File "$PLUGINSDIR\add-to-path.ps1" "$INSTDIR"'
+  Pop $R0
+
+  # Install WSL, if required
+  DetailPrint "Installing Windows Subsystem for Linux"
+  File "/oname=$PLUGINSDIR\install-wsl.ps1" "${BUILD_RESOURCES_DIR}\install-wsl.ps1"
+  nsExec::ExecToLog 'powershell.exe \
+    -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned \
+    -File "$PLUGINSDIR\install-wsl.ps1"'
+  Pop $R0
+  ${If} $R0 == "error"
+    Abort "Could not install Windows Subsystem for Linux."
+  ${ElseIf} $R0 == 0
+    # WSL was already installed
+  ${ElseIf} $R0 == 101
+    # WSL was installed, a reboot is required.
+    SetRebootFlag true
+  ${Else}
+    # Unexpected exit code
+    Abort "Unexpected error installing Windows subsystem for Linux: $R0"
+  ${EndIf}
 !macroend
 
 !macro customUnInstall

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,3 +19,4 @@ win:
   requestedExecutionLevel: asInvoker # The _app_ doesn't need privileges
 nsis:
   include: build/installer.nsh
+  oneClick: false # Needed for restart prompt

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -63,8 +63,15 @@ class Builder {
   async package() {
     console.log('Packaging...');
     const args = process.argv.slice(2).filter(x => x !== '--serial');
+    // On Windows, electron-builder will run the installer to generate the
+    // uninstall stub; however, we set the installer to be elevated, in order
+    // to ensure that we can install WSL if necessary.  To make it possible to
+    // build the installer as a non-administrator, we need to set the special
+    // environment variable `__COMPAT_LAYER=RunAsInvoker` to force the installer
+    // to run as the existing user.
+    const env = { ...process.env, __COMPAT_LAYER: 'RunAsInvoker' };
 
-    await buildUtils.spawn('node', 'node_modules/electron-builder/out/cli/cli.js', ...args);
+    await buildUtils.spawn('node', 'node_modules/electron-builder/out/cli/cli.js', ...args, { env });
   }
 
   async run() {


### PR DESCRIPTION
This changes the installer to try to install WSL automatically as part of the setup process.  This will prompt the user to restart if necessary.  Note that this means the installer is always run elevated, so that we can install Windows features.

Fixes #185 