### PR TITLE
WSL: Add logging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -194,3 +194,14 @@ Object.assign(module.exports.rules, {
   // Allow using `any` in TypeScript, until the whole project is converted.
   '@typescript-eslint/no-explicit-any':                'off',
 });
+
+module.exports.overrides = [
+  {
+    files: ['*.ts'],
+    rules: {
+      // For TypeScript, disable no-undef because the compiler checks it.
+      // Also, it is unaware of TypeScript types.
+      'no-undef': 'off',
+    }
+  }
+];

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1,6 +1,6 @@
 // Kuberentes backend for Windows, based on WSL2 + k3s
 
-import childProcess from 'child_process';
+import { Console } from 'console';
 import events from 'events';
 import fs from 'fs';
 import path from 'path';
@@ -11,12 +11,15 @@ import util from 'util';
 import fetch from 'node-fetch';
 import XDGAppPaths from 'xdg-app-paths';
 
+import * as childProcess from '../utils/childProcess';
+import Logging from '../utils/logging';
 import { Settings } from '../config/settings';
 import DownloadProgressListener from '../utils/DownloadProgressListener';
 import resources from '../resources';
 import * as K8s from './k8s';
 import K3sHelper from './k3sHelper';
 
+const console = new Console(Logging.wsl.stream);
 const paths = XDGAppPaths('rancher-desktop');
 
 export default class WSLBackend extends events.EventEmitter implements K8s.KubernetesBackend {
@@ -158,17 +161,19 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   protected async isDistroRegistered({ runningOnly = false } = {}): Promise<boolean> {
-    const execFile = util.promisify(childProcess.execFile);
     const args = ['--list', '--quiet'];
 
     if (runningOnly) {
       args.push('--running');
     }
-    const options: childProcess.ExecFileOptionsWithStringEncoding = {
+
+    const { stdout } = await childProcess.spawnFile('wsl.exe', args, {
       encoding:    'utf16le',
-      windowsHide: true
-    };
-    const { stdout } = await execFile('wsl.exe', args, options);
+      stdio:       ['ignore', 'pipe', Logging.wsl.stream],
+      windowsHide: true,
+    });
+
+    console.log(`Registered distributions: ${ stdout.replace(/\s+/g, ' ') }`);
 
     return stdout.split(/[\r\n]+/).includes('k3s');
   }
@@ -177,21 +182,24 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
    * Ensure that the distribution has been installed into WSL2.
    */
   protected async ensureDistroRegistered(): Promise<void> {
-    const execFile = util.promisify(childProcess.execFile);
-
     if (await this.isDistroRegistered()) {
       // k3s is already registered.
       return;
     }
     await this.ensureDistroFile();
     const distroPath = path.join(paths.state(), 'distro');
-    const args = ['--import', 'k3s', distroPath, this.distroFile];
-    const options: childProcess.SpawnOptions = { stdio: 'inherit', windowsHide: true };
+    const args = ['--import', 'k3s', distroPath, this.distroFile, '--version', '2'];
+    const stream = Logging.wsl.stream;
 
-    await util.promisify(fs.mkdir)(distroPath, { recursive: true });
-    await execFile('wsl.exe', args, options);
+    await fs.promises.mkdir(distroPath, { recursive: true });
+    await childProcess.spawnFile('wsl.exe', args, {
+      encoding:    'utf16le',
+      stdio:       ['ignore', stream, stream],
+      windowsHide: true
+    });
+
     if (!await this.isDistroRegistered()) {
-      throw new Error(`Error registration WSL2 distribution`);
+      throw new Error(`Error registrating WSL2 distribution`);
     }
   }
 
@@ -231,11 +239,13 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       timers.clearInterval(this.progressInterval);
       this.progressInterval = undefined;
       this.emit('progress', 0, 0);
+
       // Run run-k3s with NORUN, to set up the environment.
-      await new Promise<void>((resolve, reject) => {
-        const args = ['--distribution', 'k3s', '--exec', 'run-k3s', desiredVersion];
-        const options: childProcess.SpawnOptions = {
-          env: {
+      await childProcess.spawnFile('wsl.exe',
+        ['--distribution', 'k3s', '--exec', 'run-k3s', desiredVersion],
+        {
+          encoding: 'utf16le',
+          env:      {
             ...process.env,
             // Need to set WSLENV to let run-k3s see the CACHE_DIR variable.
             // https://docs.microsoft.com/en-us/windows/wsl/interop#share-environment-variables-between-windows-and-wsl
@@ -243,21 +253,9 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             CACHE_DIR: path.join(paths.cache(), 'k3s'),
             NORUN:     'true',
           },
-          stdio:       'inherit',
+          stdio:       ['ignore', Logging.wsl.stream, Logging.wsl.stream],
           windowsHide: true,
-        };
-        const child = childProcess.spawn('wsl.exe', args, options);
-
-        child.on('error', reject);
-        child.on('exit', (status, signal) => {
-          if (status === 0 && signal === null) {
-            return resolve();
-          }
-          const msg = status ? `status ${ status }` : `signal ${ signal }`;
-
-          reject(new Error(`Could not set up K3s; exited with ${ msg }`));
         });
-      });
 
       // Actually run K3s
       const args = ['--distribution', 'k3s', '--exec', '/usr/local/bin/k3s', 'server'];
@@ -267,7 +265,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           WSLENV:        `${ process.env.WSLENV }:IPTABLES_MODE`,
           IPTABLES_MODE: 'legacy',
         },
-        stdio:       'inherit',
+        stdio:       ['ignore', Logging.k3s.stream, Logging.k3s.stream],
         windowsHide: true,
       };
 
@@ -314,10 +312,22 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       // Right now the builder pod needs to be restarted after the remount
       // TODO: When this code is removed, make `client.getActivePod` protected again.
       try {
-        await childProcess.exec('wsl --user root -d k3s mount --make-shared /');
+        await childProcess.spawnFile(
+          'wsl.exe',
+          ['--user', 'root', '--distro', 'k3s', 'mount', '--make-shared', '/'],
+          {
+            stdio:       ['ignore', Logging.wsl.stream, Logging.wsl.stream],
+            windowsHide: true,
+          });
         console.log('Waiting for ensuring root is shared');
         await util.promisify(setTimeout)(60_000);
-        await util.promisify(childProcess.execFile)(resources.executable('kim'), ['builder', 'install', '--force', '--no-wait']);
+        await childProcess.spawnFile(
+          resources.executable('kim'),
+          ['builder', 'install', '--force', '--no-wait'],
+          {
+            stdio:       ['ignore', Logging.wsl.stream, Logging.wsl.stream],
+            windowsHide: true,
+          });
         const startTime = Date.now();
         const maxWaitTime = 120_000;
         const waitTime = 3_000;
@@ -354,17 +364,14 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   async stop(): Promise<number> {
-    const execFile = util.promisify(childProcess.execFile);
-    const options: childProcess.SpawnOptions = {
-      stdio:       'inherit',
-      windowsHide: true,
-    };
-
     try {
       this.setState(K8s.State.STOPPING);
       this.process?.kill('SIGTERM');
       try {
-        await execFile('wsl.exe', ['--terminate', 'k3s'], options);
+        await childProcess.spawnFile('wsl.exe', ['--terminate', 'k3s'], {
+          stdio:       ['ignore', Logging.wsl.stream, Logging.wsl.stream],
+          windowsHide: true,
+        });
       } catch (ex) {
         // We might have failed to terminate because it was already stopped.
         if (await this.isDistroRegistered({ runningOnly: true })) {
@@ -381,14 +388,11 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   async del(): Promise<number> {
-    const execFile = util.promisify(childProcess.execFile);
-    const options: childProcess.SpawnOptions = {
-      stdio:       'inherit',
-      windowsHide: true,
-    };
-
     await this.stop();
-    await execFile('wsl.exe', ['--unregister', 'k3s'], options);
+    await childProcess.spawnFile('wsl.exe', ['--unregister', 'k3s'], {
+      stdio:       ['ignore', Logging.wsl.stream, Logging.wsl.stream],
+      windowsHide: true,
+    });
 
     return 0;
   }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -312,7 +312,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       try {
         await childProcess.spawnFile(
           'wsl.exe',
-          ['--user', 'root', '--distro', 'k3s', 'mount', '--make-shared', '/'],
+          ['--user', 'root', '--distribution', 'k3s', 'mount', '--make-shared', '/'],
           {
             stdio:       ['ignore', await Logging.wsl.fdStream, await Logging.wsl.fdStream],
             windowsHide: true,

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -199,7 +199,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     });
 
     if (!await this.isDistroRegistered()) {
-      throw new Error(`Error registrating WSL2 distribution`);
+      throw new Error(`Error registering WSL2 distribution`);
     }
   }
 

--- a/src/utils/__tests__/childProcess.spec.ts
+++ b/src/utils/__tests__/childProcess.spec.ts
@@ -1,0 +1,45 @@
+import { execPath } from 'process';
+import * as childProcess from '../childProcess';
+
+describe(childProcess.spawnFile, () => {
+  function makeArg(fn: () => void) {
+    return `--eval=(${ fn.toString() })();`;
+  }
+
+  test('returns output', async() => {
+    const args = ['--version'];
+    const result = await childProcess.spawnFile(process.execPath, args, { stdio: ['ignore', 'pipe', 'ignore'] });
+
+    expect(result.stdout.trim()).toEqual(process.version);
+    expect(result).not.toHaveProperty('stderr');
+  });
+
+  test('returns error', async() => {
+    const args = [makeArg(() => console.error('hello'))];
+    const result = await childProcess.spawnFile(process.execPath, args, { stdio: 'pipe' });
+
+    expect(result.stdout).toEqual('');
+    expect(result.stderr.trim()).toEqual('hello');
+  });
+
+  test('throws on failure', async() => {
+    const args = [makeArg(() => process.exit(1))];
+    const result = childProcess.spawnFile(process.execPath, args);
+
+    await expect(result).rejects.toThrow('exited with code 1');
+  });
+
+  test('converts encodings on stdout', async() => {
+    const args = [makeArg(() => console.log(Buffer.from('hello', 'utf16le').toString()))];
+    const result = await childProcess.spawnFile(process.execPath, args, { stdio: 'pipe', encoding: 'utf16le' });
+
+    expect(result.stdout.trim()).toEqual('hello');
+  });
+
+  test('converts encodings on stderr', async() => {
+    const args = [makeArg(() => console.error(Buffer.from('hello', 'utf16le').toString()))];
+    const result = await childProcess.spawnFile(process.execPath, args, { stdio: 'pipe', encoding: 'utf16le' });
+
+    expect(result.stderr.trim()).toEqual('hello');
+  });
+});

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -165,9 +165,9 @@ export async function spawnFile(
         return resolve();
       }
       if (code === null) {
-        return reject(new Error(`${command} exited with signal ${signal}`));
+        return reject(new Error(`${ command } exited with signal ${ signal }`));
       }
-      reject(new Error(`${command} exited with code ${code}`));
+      reject(new Error(`${ command } exited with code ${ code }`));
     });
     child.on('error', reject);
   });

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -1,0 +1,174 @@
+import {
+  spawn, SpawnOptions,
+  SpawnOptionsWithStdioTuple, StdioPipe, StdioNull
+} from 'child_process';
+import stream from 'stream';
+
+export {
+  ChildProcess, SpawnOptions, exec, spawn
+} from 'child_process';
+
+/* eslint-disable no-redeclare */
+
+interface SpawnOptionsWithStdio<
+  Stdio extends 'pipe' | 'ignore' | 'inherit'
+  > extends SpawnOptions {
+  stdio: Stdio
+}
+
+interface SpawnOptionsEncoding {
+  /**
+   * The expected encoding of the executable.  If set, we will attempt to
+   * convert the output to strings.
+   */
+  encoding?: { stdout?: BufferEncoding, stderr?: BufferEncoding } | BufferEncoding
+}
+
+/**
+ * Wrapper around child_process.spawn() to promisify it.
+ * @param command The executable to spawn.
+ * @param args Any arguments to the executable.
+ * @param options Options to child_process.spawn();
+ */
+
+export async function spawnFile(
+  command: string,
+): Promise<Record<string, never>>;
+export async function spawnFile(
+  command: string,
+  options: SpawnOptionsWithStdio<'ignore' | 'inherit'> & SpawnOptionsEncoding,
+): Promise<Record<string, never>>;
+export async function spawnFile(
+  command: string,
+  options: SpawnOptionsWithStdio<'pipe'> & SpawnOptionsEncoding,
+): Promise<{ stdout: string, stderr: string }>;
+export async function spawnFile(
+  command: string,
+  options: SpawnOptionsWithStdioTuple<StdioNull | StdioPipe, StdioPipe, StdioPipe> & SpawnOptionsEncoding,
+): Promise<{ stdout: string, stderr: string }>;
+export async function spawnFile(
+  command: string,
+  options: SpawnOptionsWithStdioTuple<StdioNull | StdioPipe, StdioPipe, StdioNull> & SpawnOptionsEncoding,
+): Promise<{ stdout: string }>;
+export async function spawnFile(
+  command: string,
+  options: SpawnOptionsWithStdioTuple<StdioNull | StdioPipe, StdioNull, StdioPipe> & SpawnOptionsEncoding,
+): Promise<{ stderr: string }>;
+export async function spawnFile(
+  command: string,
+  options: SpawnOptionsWithStdioTuple<StdioNull | StdioPipe, StdioNull, StdioNull> & SpawnOptionsEncoding,
+): Promise<Record<string, never>>;
+
+export async function spawnFile(
+  command: string,
+  args: string[],
+): Promise<Record<string, never>>;
+export async function spawnFile(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithStdio<'ignore' | 'inherit'> & SpawnOptionsEncoding,
+): Promise<Record<string, never>>;
+export async function spawnFile(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithStdio<'pipe'> & SpawnOptionsEncoding,
+): Promise<{ stdout: string, stderr: string }>;
+export async function spawnFile(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithStdioTuple<StdioNull | StdioPipe, StdioPipe, StdioPipe> & SpawnOptionsEncoding,
+): Promise<{ stdout: string, stderr: string }>;
+export async function spawnFile(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithStdioTuple<StdioNull | StdioPipe, StdioPipe, StdioNull> & SpawnOptionsEncoding,
+): Promise<{ stdout: string }>;
+export async function spawnFile(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithStdioTuple<StdioNull | StdioPipe, StdioNull, StdioPipe> & SpawnOptionsEncoding,
+): Promise<{ stderr: string }>;
+export async function spawnFile(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithStdioTuple<StdioNull | StdioPipe, StdioNull, StdioNull> & SpawnOptionsEncoding,
+): Promise<Record<string, never>>;
+
+/* eslint-enable no-redeclare */
+// eslint-disable-next-line no-redeclare
+export async function spawnFile(
+  command: string,
+  args?: string[] | SpawnOptions & SpawnOptionsEncoding,
+  options: SpawnOptions & SpawnOptionsEncoding = {}
+): Promise<{ stdout?: string, stderr?: string }> {
+  if (args && !Array.isArray(args)) {
+    options = args;
+    args = [];
+  }
+
+  let stdio = options.stdio;
+  const encodings = [
+    undefined, // stdin
+    (typeof options.encoding === 'string') ? options.encoding : options.encoding?.stdout,
+    (typeof options.encoding === 'string') ? options.encoding : options.encoding?.stderr,
+  ];
+  const stdStreams: [undefined, stream.Writable | undefined, stream.Writable | undefined] = [undefined, undefined, undefined];
+
+  // If we're piping to a stream, and we need to override the encoding, then
+  // we need to do setup here.
+  if (Array.isArray(stdio)) {
+    // Duplicate the array, in case the caller re-uses it somewhere.
+    stdio = stdio.concat();
+    if (stdio[1] instanceof stream.Writable && encodings[1]) {
+      stdStreams[1] = stdio[1];
+      stdio[1] = 'pipe';
+    }
+    if (stdio[2] instanceof stream.Writable && encodings[2]) {
+      stdStreams[2] = stdio[2];
+      stdio[2] = 'pipe';
+    }
+  }
+
+  // Spawn the child, overriding options.stdio.  This is necessary to support
+  // transcoding the output.
+  const child = spawn(command, args || [], Object.create(options, { stdio: { value: stdio } }));
+  const resultMap: Record<number, 'stdout'|'stderr'> = { 1: 'stdout', 2: 'stderr' };
+  const result: { stdout?: string, stderr?: string } = {};
+
+  if (Array.isArray(stdio)) {
+    for (const i of [1, 2]) {
+      if (stdio[i] === 'pipe') {
+        const encoding = encodings[i];
+
+        if (!stdStreams[i]) {
+          result[resultMap[i]] = '';
+        }
+        if (encoding) {
+          child[resultMap[i]].setEncoding(encoding);
+        }
+        child[resultMap[i]].on('data', (chunk) => {
+          if (stdStreams[i]) {
+            stdStreams[i]?.write(chunk);
+          } else {
+            result[resultMap[i]] += chunk;
+          }
+        });
+      }
+    }
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    child.on('exit', (code, signal) => {
+      if ((code === 0 && signal === null) || (code === null && signal === 'SIGTERM')) {
+        return resolve();
+      }
+      if (code === null) {
+        return reject(`${ command } exited with signal ${ signal }`);
+      }
+      reject(`${ command } exited with code ${ code }`);
+    });
+    child.on('error', reject);
+  });
+
+  return result;
+}

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -127,12 +127,14 @@ export async function spawnFile(
       stdStreams[2] = stdio[2];
       stdio[2] = 'pipe';
     }
+  } else if (typeof stdio === 'string') {
+    stdio = [stdio, stdio, stdio];
   }
 
   // Spawn the child, overriding options.stdio.  This is necessary to support
   // transcoding the output.
   const child = spawn(command, args || [], Object.create(options, { stdio: { value: stdio } }));
-  const resultMap: Record<number, 'stdout'|'stderr'> = { 1: 'stdout', 2: 'stderr' };
+  const resultMap: Record<number, 'stdout' | 'stderr'> = { 1: 'stdout', 2: 'stderr' };
   const result: { stdout?: string, stderr?: string } = {};
 
   if (Array.isArray(stdio)) {
@@ -163,9 +165,9 @@ export async function spawnFile(
         return resolve();
       }
       if (code === null) {
-        return reject(`${ command } exited with signal ${ signal }`);
+        return reject(new Error(`${command} exited with signal ${signal}`));
       }
-      reject(`${ command } exited with code ${ code }`);
+      reject(new Error(`${command} exited with code ${code}`));
     });
     child.on('error', reject);
   });


### PR DESCRIPTION
Add logging to WSL so that the output goes to a file we can track.

I added a helper module for `child_process` stuff so that I can encapsulate the dance needed to get the streams to go where I want.