### PR TITLE
Background: Don't prevent quit if shutdown fails

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -129,11 +129,11 @@ Electron.app.on('before-quit', async(event) => {
     const code = await k8smanager?.stop();
 
     console.log(`2: Child exited with code ${ code }`);
-    gone = true;
   } catch (ex) {
     console.log(`2: Child exited with code ${ ex.errCode }`);
     handleFailure(ex);
   } finally {
+    gone = true;
     imageManager.stop();
     Electron.app.quit();
   }

--- a/src/k8s-engine/hyperkit.ts
+++ b/src/k8s-engine/hyperkit.ts
@@ -450,7 +450,7 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
       throw ex;
     }
 
-    return Promise.resolve(0);
+    return 0;
   }
 
   async del(): Promise<number> {


### PR DESCRIPTION
If attempting to stop `k8smanager` fails, we should display an error and then quit anyway.  Otherwise the user will be stuck with an infinite chain of dialog boxes with no way of actually stopping.

Fixes #258