### PR TITLE
268 bump to kim 0.1.0 alpha.11

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { URL } from 'url';
+import util from 'util';
 import Electron from 'electron';
 import _ from 'lodash';
 import * as settings from './src/config/settings';
@@ -12,7 +13,6 @@ import * as K8s from './src/k8s-engine/k8s';
 import Kim from './src/k8s-engine/kim';
 import resources from './src/resources';
 import Logging from './src/utils/logging';
-const util = require('util');
 
 Electron.app.setName('Rancher Desktop');
 

--- a/background.ts
+++ b/background.ts
@@ -190,7 +190,9 @@ Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID
   if (choice === 0) {
     try {
       const maxNumAttempts = 2;
-      // Try this 2 times because sometimes the 1st deletion doesn't actually work
+      // On macOS a second attempt is needed to actually delete the image.
+      // Probably due to a timing issue on the server part of kim, but not determined why.
+      // Leave this in for windows in case it can happen there too.
       let i = 0;
 
       for (i = 0; i < maxNumAttempts; i++) {

--- a/background.ts
+++ b/background.ts
@@ -198,7 +198,7 @@ Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID
       for (i = 0; i < maxNumAttempts; i++) {
         await imageManager.deleteImage(imageID);
         await imageManager.refreshImages();
-        if (!imageManager.listImages().find(image => image.imageID === imageID)) {
+        if (!imageManager.listImages().some(image => image.imageID === imageID)) {
           break;
         }
         await util.promisify(setTimeout)(500);

--- a/background.ts
+++ b/background.ts
@@ -199,7 +199,6 @@ Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID
         await imageManager.deleteImage(imageID);
         await imageManager.refreshImages();
         if (!imageManager.listImages().find(image => image.imageID === imageID)) {
-          console.log(`Successful deletion on try #{ i + 1}`);
           break;
         }
         await util.promisify(setTimeout)(500);

--- a/scripts/download-resources.mjs
+++ b/scripts/download-resources.mjs
@@ -96,7 +96,7 @@ export default async function main() {
   }
 
   // Download Kim
-  const kimVersion = '0.1.0-alpha.10';
+  const kimVersion = '0.1.0-alpha.11';
   const kimURL = `https://github.com/rancher/kim/releases/download/v${ kimVersion }/${ exeName(`kim-${ kubePlatform }-amd64`) }`;
   const kimPath = path.join(binDir, exeName('kim'));
 

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -151,7 +151,6 @@ export default {
       imageManagerOutput:               '',
       keepImageManagerOutputWindowOpen: false,
       fieldToClear:                     '',
-      refreshImagesOnEnd:               false,
       imageOutputCuller:                null,
     };
   },
@@ -237,26 +236,22 @@ export default {
     },
     deleteImage(obj) {
       this.kimRunningCommand = `delete ${ obj.imageName }:${ obj.tag }`;
-      this.refreshImagesOnEnd = true;
       this.startRunningCommand('delete');
       ipcRenderer.send('confirm-do-image-deletion', obj.imageName.trim(), obj.imageID.trim());
     },
     doPush(obj) {
       this.kimRunningCommand = `push ${ obj.imageName }:${ obj.tag }`;
-      this.refreshImagesOnEnd = false;
       this.startRunningCommand('push');
       ipcRenderer.send('do-image-push', obj.imageName.trim(), obj.imageID.trim(), obj.tag.trim());
     },
     doBuildAnImage() {
       this.kimRunningCommand = `build ${ this.imageToBuild }`;
-      this.refreshImagesOnEnd = true;
       this.fieldToClear = 'imageToBuild';
       this.startRunningCommand('build');
       ipcRenderer.send('do-image-build', this.imageToBuild.trim());
     },
     doPullAnImage() {
       this.kimRunningCommand = `pull ${ this.imageToPull }`;
-      this.refreshImagesOnEnd = true;
       this.fieldToClear = 'imageToPull';
       this.startRunningCommand('pull');
       ipcRenderer.send('do-image-pull', this.imageToPull.trim());
@@ -274,10 +269,6 @@ export default {
         this.closeOutputWindow(null);
       }
       this.kimRunningCommand = null;
-      if (this.refreshImagesOnEnd) {
-        this.refreshImagesOnEnd = false;
-        ipcRenderer.send('do-image-list');
-      }
     },
     isDeletable(row) {
       return row.imageName !== 'moby/buildkit' && !row.imageName.startsWith('rancher/');

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -134,7 +134,7 @@ export default class Kim extends EventEmitter {
     return this.images;
   }
 
-  async refreshImages(emitChanges = true) {
+  async refreshImages() {
     try {
       const result: childResultType = await this.getImages();
 
@@ -149,9 +149,7 @@ export default class Kim extends EventEmitter {
       this.images = this.parse(result.stdout);
       // Start a new interval for image-list refreshing
       this.start();
-      if (emitChanges) {
-        this.emit('images-changed', this.images);
-      }
+      this.emit('images-changed', this.images);
     } catch (err) {
       if (!this.showedStderr) {
         if (err.stderr && !err.stdout && !err.signal) {

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -1,6 +1,7 @@
 const { EventEmitter } = require('events');
 const { spawn } = require('child_process');
 const path = require('path');
+const timers = require('timers');
 const resources = require('../resources');
 
 const REFRESH_INTERVAL = 5 * 1000;
@@ -20,7 +21,7 @@ interface imageType {
 
 export default class Kim extends EventEmitter {
   private showedStderr = false;
-  private refreshInterval: any; // TS doesn't like ReturnType<typeof setInterval>;
+  private refreshInterval: ReturnType<typeof timers.setInterval> | null = null;
   // During startup `kim images` repeatedly fires the same error message. Instead,
   // keep track of the current error and give a count instead.
   private lastErrorMessage = '';
@@ -29,12 +30,12 @@ export default class Kim extends EventEmitter {
 
   start() {
     this.stop();
-    this.refreshInterval = setInterval(this.refreshImages.bind(this), REFRESH_INTERVAL);
+    this.refreshInterval = timers.setInterval(this.refreshImages.bind(this), REFRESH_INTERVAL);
   }
 
   stop() {
     if (this.refreshInterval) {
-      clearInterval(this.refreshInterval);
+      timers.clearInterval(this.refreshInterval);
       this.refreshInterval = null;
     }
   }


### PR DESCRIPTION
Two other things going on in this PR:

1. We can move some state manipulation from `Images.vue` to `background.js` by having the latter decide when to rebuild the image list.

2. We need to attempt image deletion in a loop (albeit a loop of at most two cycles).
On macOS two attempts were needed to delete the image -- you can repro this by running the installed version of kim from the command-line with the command `.../kim rmi IMAGEID`.  This didn't happen when I built `kim` myself, only when I use the release version. The most likely reason for this is that the macOS image is built using go's cross-compiler, whereas the version I built myself was built with native tools, and there seems to be a timing issue involving the client and server. Logging doesn't show anything out of the ordinary.