### PR TITLE
Allow use of system certs

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -4,8 +4,12 @@ import path from 'path';
 import os from 'os';
 import { URL } from 'url';
 import util from 'util';
+
 import Electron from 'electron';
 import _ from 'lodash';
+import MacCA from 'mac-ca';
+import WinCA from 'win-ca';
+
 import * as settings from './src/config/settings';
 import { Tray } from './src/menu/tray.js';
 import window from './src/window/window.js';
@@ -36,6 +40,10 @@ Electron.protocol.registerSchemesAsPrivileged([
 ]);
 
 Electron.app.whenReady().then(async() => {
+  if (os.platform().startsWith('win')) {
+    // Inject the Windows certs.
+    WinCA({ inject: '+' });
+  }
   try {
     tray = new Tray();
   } catch (e) {
@@ -175,6 +183,52 @@ Electron.ipcMain.handle('settings-write', (event, arg: Partial<settings.Settings
   tray?.emit('settings-update', cfg);
 
   Electron.ipcMain.emit('k8s-restart-required');
+});
+
+// Set up certificate handling for system certificates on Windows and macOS
+Electron.app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+  if (error === 'net::ERR_CERT_INVALID') {
+    // If we're getting *this* particular error, it means it's an untrusted cert.
+    // Ask the system store.
+    console.log(`Attempting to check system certificates for ${ url } (${ certificate.subjectName }/${ certificate.fingerprint })`);
+    if (os.platform().startsWith('win')) {
+      const certs: string[] = [];
+
+      WinCA({
+        format: WinCA.der2.pem, ondata: certs, fallback: false
+      });
+      for (const cert of certs) {
+        // For now, just check that the PEM data matches exactly; this is
+        // probably a little more strict than necessary, but avoids issues like
+        // an attacker generating a cert with the same serial.
+        if (cert === certificate.data) {
+          console.log(`Accepting system certificate for ${ certificate.subjectName } (${ certificate.fingerprint })`);
+          // eslint-disable-next-line node/no-callback-literal
+          callback(true);
+
+          return;
+        }
+      }
+    } else if (os.platform() === 'darwin') {
+      for (const cert of MacCA.all(MacCA.der2.pem)) {
+        // For now, just check that the PEM data matches exactly; this is
+        // probably a little more strict than necessary, but avoids issues like
+        // an attacker generating a cert with the same serial.
+        if (cert === certificate.data) {
+          console.log(`Accepting system certificate for ${ certificate.subjectName } (${ certificate.fingerprint })`);
+          // eslint-disable-next-line node/no-callback-literal
+          callback(true);
+
+          return;
+        }
+      }
+    }
+  }
+
+  console.log(`Not handling certificate error ${ error } for ${ url }`);
+
+  // eslint-disable-next-line node/no-callback-literal
+  callback(false);
 });
 
 Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "jquery": "^3.5.1",
         "jsonpath": "^1.0.2",
         "lodash": "^4.17.20",
+        "mac-ca": "^1.0.6",
         "node-fetch": "^2.6.1",
         "sass": "^1.32.2",
         "semver": "^7.3.5",
@@ -29,6 +30,7 @@
         "vue-select": "^3.11.2",
         "vue-shortkey": "^3.1.7",
         "vue-slider-component": "^3.2.11",
+        "win-ca": "^3.4.5",
         "xdg-app-paths": "^5.4.1"
       },
       "devDependencies": {
@@ -13663,6 +13665,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+    },
     "node_modules/is-extendable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -15708,6 +15715,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/mac-ca": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/mac-ca/-/mac-ca-1.0.6.tgz",
+      "integrity": "sha512-uuCaT+41YtIQlDDvbigP1evK1iUk97zRirP9+8rZJz8x0eIQZG8Z7YQegMTsCiMesLPb6LBgCS95uyAvVA1tmg==",
+      "dependencies": {
+        "node-forge": "^0.10.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -16498,6 +16513,14 @@
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "engines": {
         "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/node-gyp": {
@@ -18006,7 +18029,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -21862,6 +21884,17 @@
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
@@ -22857,8 +22890,7 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -25062,6 +25094,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/win-ca": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/win-ca/-/win-ca-3.4.5.tgz",
+      "integrity": "sha512-2xTLq3jah7Sg8Pt8me2rbTnDMxulrX6gSfU9lscyqjyE4gj34sd9w6LK0v8aNHzow+s0WEX1vve58EixZbXiLg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "is-electron": "^2.2.0",
+        "make-dir": "^1.3.0",
+        "node-forge": "^0.10.0",
+        "split": "^1.0.1"
+      }
+    },
+    "node_modules/win-ca/node_modules/make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/word-wrap": {
@@ -36440,6 +36495,11 @@
       "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
       "dev": true
     },
+    "is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+    },
     "is-extendable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -38087,6 +38147,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "mac-ca": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/mac-ca/-/mac-ca-1.0.6.tgz",
+      "integrity": "sha512-uuCaT+41YtIQlDDvbigP1evK1iUk97zRirP9+8rZJz8x0eIQZG8Z7YQegMTsCiMesLPb6LBgCS95uyAvVA1tmg==",
+      "requires": {
+        "node-forge": "^0.10.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -38732,6 +38800,11 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -39923,8 +39996,7 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -43087,6 +43159,14 @@
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
@@ -43879,8 +43959,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
@@ -45641,6 +45720,27 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
+    "win-ca": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/win-ca/-/win-ca-3.4.5.tgz",
+      "integrity": "sha512-2xTLq3jah7Sg8Pt8me2rbTnDMxulrX6gSfU9lscyqjyE4gj34sd9w6LK0v8aNHzow+s0WEX1vve58EixZbXiLg==",
+      "requires": {
+        "is-electron": "^2.2.0",
+        "make-dir": "^1.3.0",
+        "node-forge": "^0.10.0",
+        "split": "^1.0.1"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/lodash": "^4.14.168",
         "@types/node": ">=12 <12.17",
         "@types/node-fetch": "^2.5.10",
+        "@types/node-forge": "^0.9.7",
         "@types/semver": "^7.3.4",
         "@typescript-eslint/eslint-plugin": "^4.17.0",
         "@typescript-eslint/parser": "^4.17.0",
@@ -4742,6 +4743,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-0.9.7.tgz",
+      "integrity": "sha512-AX7Mqk5ztzSvxqsA/q8y0k0/znJpW6QAqnoLQMEi7A3tio+laRmC/8Q3gbATHT4kZnvhnDmGAy1CpWFzlzCfeA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -29336,6 +29346,15 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/node-forge": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-0.9.7.tgz",
+      "integrity": "sha512-AX7Mqk5ztzSvxqsA/q8y0k0/znJpW6QAqnoLQMEi7A3tio+laRmC/8Q3gbATHT4kZnvhnDmGAy1CpWFzlzCfeA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/lodash": "^4.14.168",
     "@types/node": ">=12 <12.17",
     "@types/node-fetch": "^2.5.10",
+    "@types/node-forge": "^0.9.7",
     "@types/semver": "^7.3.4",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jquery": "^3.5.1",
     "jsonpath": "^1.0.2",
     "lodash": "^4.17.20",
+    "mac-ca": "^1.0.6",
     "node-fetch": "^2.6.1",
     "sass": "^1.32.2",
     "semver": "^7.3.5",
@@ -39,6 +40,7 @@
     "vue-select": "^3.11.2",
     "vue-shortkey": "^3.1.7",
     "vue-slider-component": "^3.2.11",
+    "win-ca": "^3.4.5",
     "xdg-app-paths": "^5.4.1"
   },
   "devDependencies": {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,11 +1,16 @@
 // This file contains the code to work with the settings.json file along with
 // code docs on it.
 
+import { Console } from 'console';
 import fs from 'fs';
 import util from 'util';
 import { dirname, join } from 'path';
+
 import _ from 'lodash';
 
+import Logging from '../utils/logging';
+
+const console = new Console(Logging.settings.stream);
 const paths = require('xdg-app-paths')({ name: 'rancher-desktop' });
 
 // Settings versions are independent of app versions.
@@ -103,6 +108,7 @@ export async function clear() {
 export function init(availableVersions: readonly string[]): Settings {
   let settings: Settings;
 
+  console.log(`Initializing with ${ availableVersions.length } versions`);
   try {
     settings = load(availableVersions);
   } catch (err) {

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -1,4 +1,5 @@
 import childProcess from 'child_process';
+import { Console } from 'console';
 import crypto from 'crypto';
 import events from 'events';
 import fs from 'fs';
@@ -12,10 +13,12 @@ import semver from 'semver';
 import XDGAppPaths from 'xdg-app-paths';
 import { KubeConfig } from '@kubernetes/client-node';
 
+import Logging from '../utils/logging';
 import resources from '../resources';
 import DownloadProgressListener from '../utils/DownloadProgressListener';
 import { VersionLister } from './k8s';
 
+const console = new Console(Logging.k3s.stream);
 const paths = XDGAppPaths('rancher-desktop');
 
 export interface ReleaseAPIEntry {
@@ -162,6 +165,7 @@ export default class K3sHelper extends events.EventEmitter implements VersionLis
 
       await this.readCache();
 
+      console.log('Updating release version cache');
       while (wantMoreVersions && url) {
         const response = await fetch(url, { headers: { Accept: this.releaseApiAccept } });
 

--- a/src/typings/mac-ca.d.ts
+++ b/src/typings/mac-ca.d.ts
@@ -1,0 +1,56 @@
+declare module 'mac-ca/lib/fomatter' {
+  // eslint-disable-next-line import/no-duplicates
+  import * as forge from 'node-forge';
+
+  export enum validFormats {
+    der = 0,
+    pem = 1,
+    txt = 2,
+    asn1 = 3,
+  }
+
+  export interface Asn1 {
+    serial: forge.asn1.Asn1;
+    issuer: forge.asn1.Asn1;
+    valid: forge.asn1.Asn1;
+    subject: forge.asn1.Asn1;
+  }
+
+  /* eslint-disable no-redeclare */
+  export function transform(format: validFormats.der): forge.util.ByteStringBuffer;
+  export function transform(format: validFormats.pem): string;
+  export function transform(format: validFormats.txt): string;
+  export function transform(format: validFormats.asn1): Asn1;
+  export function transform(format: undefined): forge.pki.Certificate;
+  /* eslint-enable no-redeclare */
+}
+
+declare module 'mac-ca' {
+  // eslint-disable-next-line import/no-duplicates
+  import * as forge from 'node-forge';
+  import { transform, validFormats, Asn1 } from 'mac-ca/lib/fomatter';
+
+  export { validFormats as der2 };
+
+  type transformResult = ReturnType<typeof transform>;
+
+  /* eslint-disable no-redeclare */
+  export function all(format: validFormats.der): forge.util.ByteStringBuffer[];
+  export function all(format: validFormats.pem): string[];
+  export function all(format: validFormats.txt): string[];
+  export function all(format: validFormats.asn1): Asn1[];
+  export function all(format?: undefined): forge.pki.Certificate[];
+  /* eslint-enable no-redeclare */
+
+  type eachCallback = (item: transformResult) => void;
+
+  /* eslint-disable no-redeclare */
+  export function each(callback: (certificate: forge.pki.Certificate) => void): void;
+  export function each(format: validFormats.der, callback: (der: forge.util.ByteStringBuffer) => void): void;
+  export function each(format: validFormats.pem, callback: (pem: string) => void): void;
+  export function each(format: validFormats.txt, callback: (text: string) => void): void;
+  export function each(format: validFormats.asn1, callback: (asn1: Asn1) => void): void;
+  export function each(format: undefined, callback: (certificate: forge.pki.Certificate) => void): void;
+  export function each(callback: (certificate: forge.pki.Certificate) => void): void;
+  /* eslint-enable no-redeclare */
+}

--- a/src/typings/win-ca.d.ts
+++ b/src/typings/win-ca.d.ts
@@ -1,0 +1,90 @@
+declare module 'win-ca/der2' {
+  import * as forge from 'node-forge';
+
+  namespace der2 {
+    export enum format {
+      der = 0,
+      pem = 1,
+      txt = 2,
+      asn1 = 3,
+      x509 = 4,
+      forge = x509,
+    }
+    const der: typeof format.der;
+    const pem: typeof format.pem;
+    const txt: typeof format.txt;
+    const asn1: typeof format.asn1;
+    const x509: typeof format.x509;
+    const forge: typeof format.forge;
+  }
+
+  /** Types that Buffer.from() can take as an argument. */
+  type bufferFromType = number[] | ArrayBuffer | SharedArrayBuffer | Buffer
+
+  function der(it: Buffer | bufferFromType): Buffer;
+
+  function pem(it: Buffer | bufferFromType): string
+
+  function txt(it: Buffer): string
+
+  interface Asn1 {
+    serial: forge.asn1.Asn1;
+    issuer: forge.asn1.Asn1;
+    valid: forge.asn1.Asn1;
+    subject: forge.asn1.Asn1;
+  }
+
+  function asn1(it: Buffer): Asn1;
+
+  function x509(it: Buffer): forge.pki.Certificate;
+
+  function der2(): typeof der;
+  function der2(format: der2.format.der): typeof der;
+  function der2(format: der2.format.der, blob: Buffer | bufferFromType): Buffer;
+  function der2(format: der2.format.pem): typeof pem;
+  function der2(format: der2.format.pem, blob: Buffer | bufferFromType): string;
+  function der2(format: der2.format.txt): typeof txt;
+  function der2(format: der2.format.txt, blob: Buffer): string;
+  function der2(format: der2.format.asn1): typeof asn1;
+  function der2(format: der2.format.asn1, blob: Buffer): Asn1;
+  function der2(format: der2.format.x509): typeof x509;
+  function der2(format: der2.format.x509, blob: Buffer): forge.pki.Certificate;
+
+  export default der2;
+
+}
+
+declare module 'win-ca/lib/save' {
+
+}
+
+declare module 'win-ca' {
+  import _der2 from 'win-ca/der2';
+
+  interface apiOptions {
+    disabled?: boolean;
+    fallback?: boolean;
+    store?: string[];
+    async?: boolean;
+    unique?: boolean;
+    format?: _der2.format;
+    ondata?: any[] | ((cert: any) => void);
+    onend?: () => void;
+    generator?: boolean;
+    inject?: boolean | '+';
+    save?: boolean | string | string[];
+    onsave?: (path: string | undefined) => void;
+  }
+  namespace api {
+    namespace der2 {
+      const der = _der2.der;
+      const pem = _der2.pem;
+      const txt = _der2.txt;
+      const asn1 = _der2.asn1;
+      const x509 = _der2.x509;
+      const forge = _der2.forge;
+    }
+  }
+  function api(params?: apiOptions): void;
+  export default api;
+}


### PR DESCRIPTION
This pulls in [`mac-ca`] and [`win-ca`] as dependencies, such that we will accept certificates installed system-wide.  Tested with a [small stub] replying GitHub releases reply with a cert using a non-default CA.  Fixes #249.

I'm not terribly happy with `win-ca`, but I'm not sure there's a better package for it.  The API it exposes is a bit complex for what we want to do with it.

[`mac-ca`]: https://www.npmjs.com/package/mac-ca
[`win-ca`]: https://www.npmjs.com/package/win-ca
[small stub]: https://github.com/mook-as/github-releases-fake