### PR TITLE
Electron-builder: Remove camera & mic strings on mac

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,6 +13,9 @@ mac:
   darkModeSupport: true
   hardenedRuntime: true
   gatekeeperAssess: false
+  extendInfo:
+    NSCameraUsageDescription: ~
+    NSMicrophoneUsageDescription: ~
 afterSign: "scripts/notarize.js"
 win:
   target: nsis


### PR DESCRIPTION
Electron-builder has default entries in Info.plist for why it might want camera and microphone usage (required on macOS 10.15+ for media access). As we are unlikely to ever want media access, remove those entries instead so that people are not confused about us possibly wanting unnecessary permissions.

Related to #208.