### PR TITLE
Avoid fs.rename in unsupported scenarios

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -145,7 +145,9 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
       this.distroProgress.max = parseInt(response.headers.get('Content-Length') || '0');
       await util.promisify(stream.pipeline)(response.body, progress, writeStream);
-      await util.promisify(fs.rename)(outPath, this.distroFile);
+      // fs.rename uses hard links under the hood, breaks on windows cross-drive renames
+      await util.promisify(fs.copyFile)(outPath, this.distroFile);
+      await util.promisify(fs.unlink)(outPath);
     } finally {
       try {
         await util.promisify(fs.unlink)(outPath);


### PR DESCRIPTION
- Known problem: can't fs.rename across windows drives,
because it uses a hard link to create the new file,
and that isn't supported.

- Could have checked for a[1] === b[1] === ':' and a[0].toUpperCase() !== b[0].toUpperCase()
but I'm doing this with an explicit copy and unlink to avoid other problems, like moving
over two mounted systems on macos.

Signed-off-by: Eric Promislow <epromislow@suse.com>