### PR TITLE
LICENSE: Use pristine Apache-2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 The Kubernetes Authors All Rights Reserved
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The previous license file had the copyright owner filled in within the sample file header section.

This is a direct copy from https://www.apache.org/licenses/LICENSE-2.0.txt

Fixes #286