### PR TITLE
NSIS: Add extra nested `resources` to PATH

### DIFF
--- a/build/add-to-path.ps1
+++ b/build/add-to-path.ps1
@@ -4,7 +4,7 @@ param($InstallDir)
 
 $TargetUser = [System.EnvironmentVariableTarget]::User
 $path = [System.Environment]::GetEnvironmentVariable('PATH', $TargetUser) -split ';'
-$desiredPath = Join-Path $InstallDir 'resources\win32\bin'
+$desiredPath = Join-Path $InstallDir 'resources\resources\win32\bin'
 if ($path -notcontains $desiredPath) {
   $path += $desiredPath
   [System.Environment]::SetEnvironmentVariable('PATH', ($path -join ';'), $TargetUser)


### PR DESCRIPTION
The extra layer is because that's where Electron puts things.

Fixes #295.